### PR TITLE
Ensure FAQ interactions initialize after DOM loads

### DIFF
--- a/src/assets/js/FAQ.js
+++ b/src/assets/js/FAQ.js
@@ -1,7 +1,9 @@
-const faqItems = Array.from(document.querySelectorAll(".cs-faq-item"));
-for (const item of faqItems) {
-    const onClick = () => {
-        item.classList.toggle("active");
-    };
-    item.addEventListener("click", onClick);
-}
+document.addEventListener("DOMContentLoaded", () => {
+    const faqItems = Array.from(document.querySelectorAll(".cs-faq-item"));
+    for (const item of faqItems) {
+        const onClick = () => {
+            item.classList.toggle("active");
+        };
+        item.addEventListener("click", onClick);
+    }
+});

--- a/src/content/pages/FAQ.html
+++ b/src/content/pages/FAQ.html
@@ -8,7 +8,7 @@ permalink: "/FAQ/"
 
 {% block head %}
 <link rel="stylesheet" href="/assets/css/FAQ.css">
-<script src="/assets/js/FAQ.js"></script>
+<script defer src="/assets/js/FAQ.js"></script>
 {% endblock %}
 
 {% block body %}


### PR DESCRIPTION
## Summary
- add a `defer` attribute to the FAQ page script include so the browser waits for the DOM before executing it
- wrap the FAQ interaction logic in a `DOMContentLoaded` handler to reliably toggle the active state when cards are clicked

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c8eeefc1788321bbff53f623c63af6