### PR TITLE
Ensure FAQ script runs after DOM ready

### DIFF
--- a/src/assets/js/FAQ.js
+++ b/src/assets/js/FAQ.js
@@ -1,7 +1,9 @@
-const faqItems = Array.from(document.querySelectorAll(".cs-faq-item"));
-for (const item of faqItems) {
-    const onClick = () => {
-        item.classList.toggle("active");
-    };
-    item.addEventListener("click", onClick);
-}
+document.addEventListener("DOMContentLoaded", () => {
+    const faqItems = Array.from(document.querySelectorAll(".cs-faq-item"));
+    for (const item of faqItems) {
+        const onClick = () => {
+            item.classList.toggle("active");
+        };
+        item.addEventListener("click", onClick);
+    }
+});

--- a/src/content/pages/FAQ.html
+++ b/src/content/pages/FAQ.html
@@ -8,7 +8,7 @@ permalink: "/FAQ/"
 
 {% block head %}
 <link rel="stylesheet" href="/assets/css/FAQ.css">
-<script src="/assets/js/FAQ.js"></script>
+<script defer src="/assets/js/FAQ.js"></script>
 {% endblock %}
 
 {% block body %}


### PR DESCRIPTION
## Summary
- defer the FAQ page script so it executes after the document is parsed
- wrap the FAQ toggle logic in a DOMContentLoaded handler to avoid missing elements

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c8f0e9ce848321a929e4f00bc85084