### PR TITLE
Align dark mode palette with new accent variables

### DIFF
--- a/src/assets/less/FAQ.less
+++ b/src/assets/less/FAQ.less
@@ -230,10 +230,10 @@
 @media only screen and (min-width: 0rem) {
   body.dark-mode {
     #faq-2407 {
-      background-color: rgba(0, 0, 0, 0.2);
+      background-color: var(--darkBackground);
 
       .cs-topper {
-        color: var(--primaryLight);
+        color: var(--darkSecondaryAccent);
       }
 
       .cs-title,
@@ -242,11 +242,15 @@
       }
 
       .cs-faq-item {
-        background-color: var(--medium);
+        background-color: var(--darkBackground);
+
+        &:before {
+          background: var(--darkPrimaryAccent);
+        }
 
         &.active {
           .cs-button {
-            color: var(--primaryLight);
+            color: var(--darkPrimaryAccent);
           }
         }
       }

--- a/src/assets/less/about.less
+++ b/src/assets/less/about.less
@@ -267,7 +267,7 @@
 @media only screen and (min-width: 0rem) {
     body.dark-mode {
         #content-page-714 {
-            background-color: var(--dark);
+            background-color: var(--darkBackground);
 
             .cs-title,
             .cs-text,
@@ -282,17 +282,17 @@
             }
             .cs-color,
             a {
-                color: var(--primaryLight);
+                color: var(--darkPrimaryAccent);
             }
 
             p,
             li {
-                color: #ebebeb;
+                color: var(--bodyTextColorWhite);
             }
 
             .cs-picture {
-                border-color: var(--dark);
-                background-color: var(--dark);
+                border-color: var(--darkBackground);
+                background-color: var(--darkBackground);
             }
 
             .cs-flower {
@@ -304,7 +304,7 @@
             }
 
             .cs-background {
-                background-color: var(--medium);
+                background-color: var(--darkBackground);
                 filter: brightness(70%);
                 img {
                     opacity: 0.1;

--- a/src/assets/less/blog.less
+++ b/src/assets/less/blog.less
@@ -183,10 +183,10 @@
 
             .cs-toc-item {
                 &.cs-active {
-                    border-color: var(--secondary);
+                    border-color: var(--darkSecondaryAccent);
 
                     .cs-toc-link {
-                        color: var(--secondary);
+                        color: var(--darkSecondaryAccent);
                     }
                 }
             }
@@ -500,7 +500,7 @@
             a:not(.cs-button-solid) {
                 text-decoration: underline;
                 font-size: inherit;
-                color: var(--secondary);
+                color: var(--darkSecondaryAccent);
             }
 
             .cs-button-solid {

--- a/src/assets/less/contact.less
+++ b/src/assets/less/contact.less
@@ -349,7 +349,7 @@
             }
 
             .cs-bg-picture {
-                background-color: #000;
+                background-color: var(--darkBackground);
 
                 img {
                     /* lets parent background-color bleed through and darken it */

--- a/src/assets/less/googlePpcAds.less
+++ b/src/assets/less/googlePpcAds.less
@@ -254,17 +254,17 @@
 @media only screen and (min-width: 0rem) {
   body.dark-mode {
     #content-page-1532 {
-      background-color: var(--dark);
+      background-color: var(--darkBackground);
 
       .cs-title, .cs-text, h2, h3, h4, h5, h6, li, p {
         color: var(--bodyTextColorWhite);
       }
       .cs-color, a {
-        color: var(--primaryLight);
+        color: var(--darkPrimaryAccent);
       }
 
       p, li {
-        color: #ebebeb;
+        color: var(--bodyTextColorWhite);
       }
 
       .cs-floater {

--- a/src/assets/less/local.less
+++ b/src/assets/less/local.less
@@ -391,7 +391,7 @@
 
             .cs-title {
                 &:before {
-                    background-color: var(--primary);
+                    background-color: var(--darkPrimaryAccent);
                     opacity: .2;
                 }
             }
@@ -514,10 +514,10 @@
 @media only screen and (min-width: 0rem) {
     body.dark-mode {
         #services-2377 {
-            background-color: var(--background);
+            background-color: var(--darkBackground);
 
             .cs-item {
-                background-color: var(--darkBackground );
+                background-color: var(--darkBackground);
             }
 
             .cs-title,
@@ -795,7 +795,7 @@
             }
 
             .cs-link {
-                color: var(--secondaryLight);
+                color: var(--darkSecondaryAccent);
             }
 
             .cs-text,
@@ -1144,11 +1144,11 @@
 @media only screen and (min-width: 0rem) {
     body.dark-mode {
         #pricing-1843 {
-            background-color: #0F2C59;
+            background-color: var(--darkBackground);
 
             .cs-item {
-                background-color: var(--dark);
-                border-color: var(--medium);
+                background-color: var(--darkBackground);
+                border-color: var(--darkPrimaryAccent);
                 position: relative;
                 z-index: 1;
 
@@ -1157,7 +1157,7 @@
                     width: 100%;
                     height: 100%;
                     border-radius: (40/16rem);
-                    background: #000;
+                    background: var(--darkBackground);
                     opacity: .6;
                     position: absolute;
                     display: block;
@@ -1167,14 +1167,30 @@
             }
 
             .cs-price-box {
-                background-color: var(--medium);
-                border-color: var(--dark);
+                background-color: var(--darkBackground);
+                border-color: var(--darkSecondaryAccent);
+
+                &:before {
+                    background: var(--darkBackground);
+                }
             }
 
             .cs-vip {
                 &:before {
-                    background-color: #000;
+                    background-color: var(--darkBackground);
                     opacity: .6;
+                }
+            }
+
+            .cs-topper {
+                color: var(--darkSecondaryAccent);
+            }
+
+            .cs-package {
+                background-color: var(--darkSecondaryAccent);
+
+                &:before {
+                    background: var(--darkSecondaryAccent);
                 }
             }
 
@@ -1197,7 +1213,7 @@
                 color: var(--buttonText);
                 padding: 0 (48/16rem);
                 border-radius: (30/16rem);
-                background-color: #00BFFF;
+                background-color: var(--darkSecondaryAccent);
                 display: inline-block;
                 position: relative;
                 z-index: 1;
@@ -1209,7 +1225,7 @@
                     display: block;
                     height: 100%;
                     width: 0%;
-                    background: var(--primary);
+                    background: var(--darkPrimaryAccent);
                     opacity: 1;
                     top: 0;
                     left: 0;
@@ -1471,7 +1487,7 @@
             }
 
             .cs-review {
-                background: var(--medium);
+                background: var(--darkBackground);
             }
         }
     }

--- a/src/assets/less/reviews.less
+++ b/src/assets/less/reviews.less
@@ -156,11 +156,11 @@
             }
 
             .cs-item {
-                background: rgba(0, 0, 0, 0.2);
+                background: var(--darkBackground);
             }
 
             .cs-desc {
-                color: var(--primaryLight);
+                color: var(--bodyTextColorWhite);
             }
         }
     }

--- a/src/assets/less/root.less
+++ b/src/assets/less/root.less
@@ -26,7 +26,7 @@
         --accent: #0180ff;
 
         /* Dark Mode Styles */
-        --darkBackground:082032;
+        --darkBackground: #082032;
         --darkPrimaryAccent:#0F2C59;
         --darkSecondaryAccent:#00BFFF;
         --dark: #082032;
@@ -231,8 +231,8 @@
         }
 
         .cs-button-outline {
-            border-color: #fff;
-            color: #fff;
+            border-color: var(--bodyTextColorWhite);
+            color: var(--bodyTextColorWhite);
         }
     }
 }
@@ -295,7 +295,7 @@
         h4,
         h5,
         h6 {
-            color: #fff;
+            color: var(--bodyTextColorWhite);
         }
     }
 }
@@ -350,7 +350,7 @@
             .cs-moon {
                 opacity: 0;
                 transform: translate(-50%, -150%);
-                fill: #fff;
+                fill: var(--bodyTextColorWhite);
             }
         }
     }
@@ -693,11 +693,11 @@
             }
 
             .cs-line {
-                background-color: var(--background);
+                background-color: var(--bodyTextColorWhite);
             }
 
             .cs-ul-wrapper {
-                background-color: var(--medium);
+                background-color: var(--darkBackground);
             }
 
             .cs-li-link {
@@ -1062,7 +1062,7 @@
 
             .cs-li-link {
                 &:before {
-                    background-color: var(--primary);
+                    background-color: var(--darkPrimaryAccent);
                 }
             }
         }

--- a/src/assets/less/seo.less
+++ b/src/assets/less/seo.less
@@ -254,17 +254,17 @@
 @media only screen and (min-width: 0rem) {
   body.dark-mode {
     #content-page-1532 {
-      background-color: var(--dark);
+      background-color: var(--darkBackground);
 
       .cs-title, .cs-text, h2, h3, h4, h5, h6, li, p {
         color: var(--bodyTextColorWhite);
       }
       .cs-color, a {
-        color: var(--primaryLight);
+        color: var(--darkPrimaryAccent);
       }
 
       p, li {
-        color: #ebebeb;
+        color: var(--bodyTextColorWhite);
       }
 
       .cs-floater {

--- a/src/assets/less/webDesign.less
+++ b/src/assets/less/webDesign.less
@@ -254,17 +254,17 @@
 @media only screen and (min-width: 0rem) {
   body.dark-mode {
     #content-page-1532 {
-      background-color: var(--dark);
+      background-color: var(--darkBackground);
 
       .cs-title, .cs-text, h2, h3, h4, h5, h6, li, p {
         color: var(--bodyTextColorWhite);
       }
       .cs-color, a {
-        color: var(--primaryLight);
+        color: var(--darkPrimaryAccent);
       }
 
       p, li {
-        color: #ebebeb;
+        color: var(--bodyTextColorWhite);
       }
 
       .cs-floater {


### PR DESCRIPTION
## Summary
- update the global dark-mode palette and navigation elements to use the shared background, primary, and secondary variables
- map interior content pages (about, FAQ, and marketing landing pages) to the dark background and accent tokens while keeping body copy white
- refresh home-page sections, services, pricing, reviews, and blog callouts to apply dark backgrounds and accents consistently

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c983c13eb88321b6d1043d31f3779a