### PR TITLE
Ensure dark mode text uses body text color

### DIFF
--- a/src/assets/less/FAQ.less
+++ b/src/assets/less/FAQ.less
@@ -232,10 +232,6 @@
     #faq-2407 {
       background-color: var(--darkBackground);
 
-      .cs-topper {
-        color: var(--darkSecondaryAccent);
-      }
-
       .cs-title,
       .cs-item-p {
         color: var(--bodyTextColorWhite);
@@ -250,7 +246,7 @@
 
         &.active {
           .cs-button {
-            color: var(--darkPrimaryAccent);
+            color: var(--bodyTextColorWhite);
           }
         }
       }

--- a/src/assets/less/about.less
+++ b/src/assets/less/about.less
@@ -282,7 +282,7 @@
             }
             .cs-color,
             a {
-                color: var(--darkPrimaryAccent);
+                color: var(--bodyTextColorWhite);
             }
 
             p,

--- a/src/assets/less/blog.less
+++ b/src/assets/less/blog.less
@@ -186,7 +186,7 @@
                     border-color: var(--darkSecondaryAccent);
 
                     .cs-toc-link {
-                        color: var(--darkSecondaryAccent);
+                        color: var(--bodyTextColorWhite);
                     }
                 }
             }

--- a/src/assets/less/googlePpcAds.less
+++ b/src/assets/less/googlePpcAds.less
@@ -260,7 +260,7 @@
         color: var(--bodyTextColorWhite);
       }
       .cs-color, a {
-        color: var(--darkPrimaryAccent);
+        color: var(--bodyTextColorWhite);
       }
 
       p, li {

--- a/src/assets/less/local.less
+++ b/src/assets/less/local.less
@@ -795,7 +795,7 @@
             }
 
             .cs-link {
-                color: var(--darkSecondaryAccent);
+                color: var(--bodyTextColorWhite);
             }
 
             .cs-text,
@@ -1183,7 +1183,7 @@
             }
 
             .cs-topper {
-                color: var(--darkSecondaryAccent);
+                color: var(--bodyTextColorWhite);
             }
 
             .cs-package {
@@ -1473,7 +1473,7 @@
         #reviews-287 {
             background-color: var(--darkBackground);
             .cs-topper {
-                color: var(--darkSecondaryAccent);
+                color: var(--bodyTextColorWhite);
             }
 
             .cs-title,

--- a/src/assets/less/root.less
+++ b/src/assets/less/root.less
@@ -286,6 +286,11 @@
 
     body.dark-mode {
         background-color: var(--darkBackground);
+        color: var(--bodyTextColorWhite);
+
+        * {
+            color: inherit;
+        }
 
         p,
         li,
@@ -295,7 +300,14 @@
         h4,
         h5,
         h6 {
-            color: var(--bodyTextColorWhite);
+            color: inherit;
+        }
+
+        p,
+        li {
+            a {
+                color: inherit;
+            }
         }
     }
 }

--- a/src/assets/less/seo.less
+++ b/src/assets/less/seo.less
@@ -260,7 +260,7 @@
         color: var(--bodyTextColorWhite);
       }
       .cs-color, a {
-        color: var(--darkPrimaryAccent);
+        color: var(--bodyTextColorWhite);
       }
 
       p, li {

--- a/src/assets/less/webDesign.less
+++ b/src/assets/less/webDesign.less
@@ -260,7 +260,7 @@
         color: var(--bodyTextColorWhite);
       }
       .cs-color, a {
-        color: var(--darkPrimaryAccent);
+        color: var(--bodyTextColorWhite);
       }
 
       p, li {


### PR DESCRIPTION
## Summary
- enforce a global dark mode base color and inheritance so typography consistently uses `--bodyTextColorWhite`
- keep FAQ question buttons white after toggling in dark mode to match the rest of the section
- align page-specific dark mode overrides so Google PPC, Web Design, SEO, About, Blog, and Local views reuse the shared text color variable

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9916b34548321bd0a67d4c55db9a1