### PR TITLE
Fix dark mode text colors in services section

### DIFF
--- a/src/assets/less/local.less
+++ b/src/assets/less/local.less
@@ -219,6 +219,10 @@
     body.dark-mode #services-965 {
         background-color: var(--darkBackground);
     }
+    body.dark-mode #services-965 .cs-title,
+    body.dark-mode #services-965 .cs-text {
+        color: var(--bodyTextColorWhite);
+    }
 }
 
 


### PR DESCRIPTION
## Summary
- update the Services section dark-mode styles so the heading and description use the light body text color variable

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9aa32894c83219e1f87932fa34693