### PR TITLE
Fix dark mode stat text color

### DIFF
--- a/src/assets/less/local.less
+++ b/src/assets/less/local.less
@@ -802,6 +802,10 @@
                 color: var(--bodyTextColorWhite);
             }
 
+            .cs-number {
+                color: var(--bodyTextColorWhite);
+            }
+
             .cs-text,
             .cs-h3 {
                 opacity: 0.8;


### PR DESCRIPTION
## Summary
- ensure the side-by-side stats numbers adopt the white text token in dark mode for readability

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9bc06112c83218853558b805c17e4