### PR TITLE
Ensure secondary accent text color persists in dark mode

### DIFF
--- a/src/assets/less/local.less
+++ b/src/assets/less/local.less
@@ -1191,7 +1191,7 @@
             }
 
             .cs-topper {
-                color: var(--bodyTextColorWhite);
+                color: var(--secondary);
             }
 
             .cs-package {
@@ -1481,7 +1481,7 @@
         #reviews-287 {
             background-color: var(--darkBackground);
             .cs-topper {
-                color: var(--bodyTextColorWhite);
+                color: var(--secondary);
             }
 
             .cs-title,

--- a/src/assets/less/root.less
+++ b/src/assets/less/root.less
@@ -292,6 +292,10 @@
             color: inherit;
         }
 
+        .cs-topper {
+            color: var(--secondary);
+        }
+
         p,
         li,
         h1,


### PR DESCRIPTION
## Summary
- keep cs-topper text using the secondary accent color when dark mode is active
- update pricing and reviews dark-mode overrides so their toppers retain the accent color instead of turning white

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9c3e89cdc8321be85ecb834971f59