### PR TITLE
Align banner breadcrumb active color with first link

### DIFF
--- a/src/assets/less/root.less
+++ b/src/assets/less/root.less
@@ -1159,7 +1159,7 @@
             }
 
             &.cs-active {
-                color: var(--primaryLight);
+                color: var(--bodyTextColorWhite);
             }
         }
 


### PR DESCRIPTION
## Summary
- set the banner breadcrumb active link color to share the same token as the default breadcrumb links

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9cc76b7b08321b9c994a3b917273c