### PR TITLE
Align banner breadcrumb styling and links

### DIFF
--- a/src/assets/less/root.less
+++ b/src/assets/less/root.less
@@ -1159,7 +1159,7 @@
             }
 
             &.cs-active {
-                color: var(--primaryLight);
+                color: var(--bodyTextColorWhite);
             }
         }
 

--- a/src/content/pages/FAQ.html
+++ b/src/content/pages/FAQ.html
@@ -22,7 +22,7 @@ permalink: "/FAQ/"
         <span class="cs-int-title">FAQ</span>
         <div class="cs-breadcrumbs">
             <a href="/" class="cs-link">Home</a>
-            <a href="/contact/" class="cs-link cs-active">FAQ</a>
+            <a href="/FAQ/" class="cs-link cs-active">FAQ</a>
         </div>
     </div>
     <!--Background Image-->

--- a/src/content/pages/googlePpcAds.html
+++ b/src/content/pages/googlePpcAds.html
@@ -21,7 +21,7 @@ permalink: "/googlePpcAds/"
         <span class="cs-int-title">Pay per click ads</span>
         <div class="cs-breadcrumbs">
             <a href="/" class="cs-link">Home</a>
-            <a href="/contact/" class="cs-link cs-active">Pay per click ads</a>
+            <a href="/googlePpcAds/" class="cs-link cs-active">Pay per click ads</a>
         </div>
     </div>
     <!--Background Image-->

--- a/src/content/pages/seo.html
+++ b/src/content/pages/seo.html
@@ -21,7 +21,7 @@ permalink: "/SEO/"
         <span class="cs-int-title">SEO</span>
         <div class="cs-breadcrumbs">
             <a href="/" class="cs-link">Home</a>
-            <a href="/contact/" class="cs-link cs-active">SEO</a>
+            <a href="/SEO/" class="cs-link cs-active">SEO</a>
         </div>
     </div>
     <!--Background Image-->

--- a/src/content/pages/webDesign.html
+++ b/src/content/pages/webDesign.html
@@ -23,7 +23,7 @@ permalink: "/webDesign/"
         <span class="cs-int-title">Web Design</span>
         <div class="cs-breadcrumbs">
             <a href="/" class="cs-link">Home</a>
-            <a href="/contact/" class="cs-link cs-active">Web Deisgn</a>
+            <a href="/webDesign/" class="cs-link cs-active">Web Design</a>
         </div>
     </div>
     <!--Background Image-->


### PR DESCRIPTION
## Summary
- set the banner breadcrumb active link color to share the same token as the default breadcrumb links
- correct the second breadcrumb banner links so each service page points to its own permalink

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9cc76b7b08321b9c994a3b917273c