### PR TITLE
Update dark mode FAQ card backgrounds

### DIFF
--- a/src/assets/less/FAQ.less
+++ b/src/assets/less/FAQ.less
@@ -238,13 +238,15 @@
       }
 
       .cs-faq-item {
-        background-color: var(--darkBackground);
+        background-color: var(--slightlyAboveBackground);
 
         &:before {
           background: var(--darkPrimaryAccent);
         }
 
         &.active {
+          background-color: var(--slightlyBelowBackground);
+
           .cs-button {
             color: var(--bodyTextColorWhite);
           }

--- a/src/assets/less/root.less
+++ b/src/assets/less/root.less
@@ -29,6 +29,8 @@
         --darkBackground: #082032;
         --darkPrimaryAccent:#0F2C59;
         --darkSecondaryAccent:#00BFFF;
+        --slightlyAboveBackground: #0A2C44;
+        --slightlyBelowBackground: #061A28;
         --dark: #082032;
         --medium: #2c394b;
         --accent: #334756;


### PR DESCRIPTION
## Summary
- add new dark mode background tokens for FAQ card states
- apply the new tokens to the FAQ card backgrounds when dark mode is active

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9d4b7049c8321949e47efc5c3f12f