### PR TITLE
Adjust dark mode item card background

### DIFF
--- a/src/assets/less/root.less
+++ b/src/assets/less/root.less
@@ -294,6 +294,10 @@
             color: inherit;
         }
 
+        .cs-item {
+            background-color: var(--slightlyBelowBackground);
+        }
+
         .cs-topper {
             color: var(--secondary);
         }


### PR DESCRIPTION
## Summary
- ensure the dark mode item cards use the slightly below background color variable for their background

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c9d6d37d348321aef434148859e2c1