### PR TITLE
Ensure dark mode buttons use secondary color variable

### DIFF
--- a/src/assets/less/critical.less
+++ b/src/assets/less/critical.less
@@ -142,7 +142,7 @@
             color: var(--buttonText);
             padding: 0 (48/16rem);
             border-radius: (30/16rem);
-            background-color: #00BFFF;
+            background-color: var(--secondary);
             display: inline-block;
             position: relative;
             z-index: 1;

--- a/src/assets/less/local.less
+++ b/src/assets/less/local.less
@@ -129,7 +129,7 @@
         font-weight: bold;
         margin: 0;
         padding: 0;
-        color: #00BFFF;
+        color: var(--secondary);
         position: relative;
         transition: color 0.3s;
     }
@@ -309,7 +309,7 @@
             color: var(--buttonText);
             padding: 0 (48/16rem);
             border-radius: (30/16rem);
-            background-color: #00BFFF;
+            background-color: var(--secondary);
             display: inline-block;
             position: relative;
             z-index: 1;
@@ -594,7 +594,7 @@
             color: var(--buttonText);
             padding: 0 (48/16rem);
             border-radius: (30/16rem);
-            background-color: #00BFFF;
+            background-color: var(--secondary);
             display: inline-block;
             position: relative;
             z-index: 1;
@@ -905,7 +905,7 @@
             padding: 0;
             background-color: var(--background);
             /* 30% opacity of primary color against a white background*/
-            border: 8px solid #00BFFF;
+            border: 8px solid var(--secondary);
             border-radius: (400/16rem);
             display: flex;
             flex-direction: column;
@@ -1029,7 +1029,7 @@
             color: var(--buttonText);
             padding: 0 (48/16rem);
             border-radius: (30/16rem);
-            background-color: #00BFFF;
+            background-color: var(--secondary);
             display: inline-block;
             position: relative;
             z-index: 1;
@@ -1067,7 +1067,7 @@
             color: var(--buttonText);
             padding: 0 (48/16rem);
             border-radius: (30/16rem);
-            background-color: #00BFFF;
+            background-color: var(--secondary);
             display: inline-block;
             position: relative;
             z-index: 1;
@@ -1380,7 +1380,7 @@
             color: var(--buttonText);
             padding: 0 (48/16rem);
             border-radius: (30/16rem);
-            background-color: #00BFFF;
+            background-color: var(--secondary);
             display: inline-block;
             position: relative;
             z-index: 1;

--- a/src/assets/less/root.less
+++ b/src/assets/less/root.less
@@ -294,6 +294,16 @@
             color: inherit;
         }
 
+        button,
+        input[type="button"],
+        input[type="submit"],
+        .btn,
+        .button,
+        a[role="button"] {
+            color: var(--buttonText);
+            background-color: var(--secondary);
+        }
+
         .cs-topper {
             color: var(--secondary);
         }
@@ -1261,7 +1271,7 @@
             color: var(--buttonText);
             padding: 0 (48/16rem);
             border-radius: (30/16rem);
-            background-color: #00BFFF;
+            background-color: var(--secondary);
             display: inline-block;
             position: relative;
             z-index: 1;


### PR DESCRIPTION
## Summary
- ensure dark mode button elements and roles inherit the themed secondary background and button text color
- replace remaining hard-coded #00BFFF accents in shared button and link styles with var(--secondary)

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ca178cbf508321bdd25ebb89b2c46d