### PR TITLE
Align buttons with secondary theme colors

### DIFF
--- a/src/assets/less/contact.less
+++ b/src/assets/less/contact.less
@@ -93,10 +93,10 @@
             font-weight: 700;
             text-align: center;
             margin: 0;
-            color: #fff;
+            color: var(--buttonText);
             min-width: (150/16rem);
             padding: 0 (24/16rem);
-            background-color: var(--primary);
+            background-color: var(--secondary);
             border-radius: (4/16rem);
             display: inline-block;
             position: relative;
@@ -109,7 +109,7 @@
                 position: absolute;
                 height: 100%;
                 width: 0%;
-                background: #000;
+                background-color: var(--secondary);
                 opacity: 1;
                 top: 0;
                 left: 0;
@@ -119,6 +119,7 @@
             }
 
             &:hover {
+                color: var(--buttonText);
                 &:before {
                     width: 100%;
                 }
@@ -128,6 +129,13 @@
         .cs-submit {
             width: 100%;
             border: none;
+            color: var(--buttonText);
+            background-color: var(--secondary);
+
+            &:before {
+                background-color: var(--secondary);
+            }
+
             &:hover {
                 cursor: pointer;
             }

--- a/src/assets/less/critical.less
+++ b/src/assets/less/critical.less
@@ -154,7 +154,7 @@
                 display: block;
                 height: 100%;
                 width: 0%;
-                background: var(--primary);
+                background-color: var(--secondary);
                 opacity: 1;
                 top: 0;
                 left: 0;

--- a/src/assets/less/local.less
+++ b/src/assets/less/local.less
@@ -321,7 +321,7 @@
                 display: block;
                 height: 100%;
                 width: 0%;
-                background: var(--primary);
+                background-color: var(--secondary);
                 opacity: 1;
                 top: 0;
                 left: 0;
@@ -606,7 +606,7 @@
                 display: block;
                 height: 100%;
                 width: 0%;
-                background: var(--primary);
+                background-color: var(--secondary);
                 opacity: 1;
                 top: 0;
                 left: 0;
@@ -1041,7 +1041,7 @@
                 display: block;
                 height: 100%;
                 width: 0%;
-                background: var(--primary);
+                background-color: var(--secondary);
                 opacity: 1;
                 top: 0;
                 left: 0;
@@ -1079,7 +1079,7 @@
                 display: block;
                 height: 100%;
                 width: 0%;
-                background: var(--primary);
+                background-color: var(--secondary);
                 opacity: 1;
                 top: 0;
                 left: 0;
@@ -1225,7 +1225,7 @@
                 color: var(--buttonText);
                 padding: 0 (48/16rem);
                 border-radius: (30/16rem);
-                background-color: var(--darkSecondaryAccent);
+                background-color: var(--secondary);
                 display: inline-block;
                 position: relative;
                 z-index: 1;
@@ -1237,7 +1237,7 @@
                     display: block;
                     height: 100%;
                     width: 0%;
-                    background: var(--darkPrimaryAccent);
+                    background-color: var(--secondary);
                     opacity: 1;
                     top: 0;
                     left: 0;
@@ -1392,7 +1392,7 @@
                 display: block;
                 height: 100%;
                 width: 0%;
-                background: var(--primary);
+                background-color: var(--secondary);
                 opacity: 1;
                 top: 0;
                 left: 0;

--- a/src/assets/less/projects.less
+++ b/src/assets/less/projects.less
@@ -124,10 +124,10 @@
             font-weight: 700;
             text-align: center;
             margin: 0;
-            color: #fff;
+            color: var(--buttonText);
             min-width: (150/16rem);
             padding: 0 (24/16rem);
-            background-color: var(--primary);
+            background-color: var(--secondary);
             border-radius: (4/16rem);
             display: inline-block;
             position: relative;
@@ -140,7 +140,7 @@
                 position: absolute;
                 height: 100%;
                 width: 0%;
-                background: #000;
+                background-color: var(--secondary);
                 opacity: 1;
                 top: 0;
                 left: 0;
@@ -150,6 +150,7 @@
             }
 
             &:hover {
+                color: var(--buttonText);
                 &:before {
                     width: 100%;
                 }

--- a/src/assets/less/root.less
+++ b/src/assets/less/root.less
@@ -150,7 +150,7 @@
             content: "";
             opacity: 1;
             display: block;
-            background-color: var(--primary);
+            background-color: var(--secondary);
             height: 100%;
 
             //Transition properties
@@ -1283,7 +1283,7 @@
                 display: block;
                 height: 100%;
                 width: 0%;
-                background: var(--primary);
+                background-color: var(--secondary);
                 opacity: 1;
                 top: 0;
                 left: 0;


### PR DESCRIPTION
## Summary
- update the global `.cs-button-solid` styling (including the header and CTA instances) to keep both the base and overlay backgrounds on `var(--secondary)` with `var(--buttonText)` text
- refresh the contact form submit button and projects call to action to rely on the secondary background token instead of hard-coded blues and blacks
- replace remaining section-specific button overrides so shared "local" layouts and hero areas inherit the secondary/buttonText palette consistently

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca1ace8c948321976c18de50855438