### PR TITLE
Adjust dark mode card background

### DIFF
--- a/src/assets/less/local.less
+++ b/src/assets/less/local.less
@@ -525,7 +525,7 @@
             background-color: var(--darkBackground);
 
             .cs-item {
-                background-color: var(--darkBackground);
+                background-color: var(--slightlyAboveBackground);
             }
 
             .cs-title,


### PR DESCRIPTION
## Summary
- update the dark mode services card background to use the slightly-above background color

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ca4b9019808321987849a95a8ca456