### PR TITLE
Adjust dark mode pricing card background color

### DIFF
--- a/src/assets/less/local.less
+++ b/src/assets/less/local.less
@@ -1159,7 +1159,7 @@
             background-color: var(--darkBackground);
 
             .cs-item {
-                background-color: var(--darkBackground);
+                background-color: var(--slightlyBelowBackground);
                 border-color: var(--darkPrimaryAccent);
                 position: relative;
                 z-index: 1;
@@ -1169,7 +1169,7 @@
                     width: 100%;
                     height: 100%;
                     border-radius: (40/16rem);
-                    background: var(--darkBackground);
+                    background: var(--slightlyBelowBackground);
                     opacity: .6;
                     position: absolute;
                     display: block;
@@ -1189,7 +1189,7 @@
 
             .cs-vip {
                 &:before {
-                    background-color: var(--darkBackground);
+                    background-color: var(--slightlyBelowBackground);
                     opacity: .6;
                 }
             }


### PR DESCRIPTION
## Summary
- update the dark mode pricing card background to use `var(--slightlyBelowBackground)` while keeping layout and typography intact

## Testing
- npm run build:eleventy

------
https://chatgpt.com/codex/tasks/task_e_68ca4ee6b6dc8321b0e2216a83db7c67