### PR TITLE
Adjust dark mode pricing card background

### DIFF
--- a/src/assets/less/local.less
+++ b/src/assets/less/local.less
@@ -1159,7 +1159,7 @@
             background-color: var(--darkBackground);
 
             .cs-item {
-                background-color: var(--slightlyBelowBackground);
+                background-color: var(--slightlyAboveBackground);
                 border-color: var(--darkPrimaryAccent);
                 position: relative;
                 z-index: 1;
@@ -1169,7 +1169,7 @@
                     width: 100%;
                     height: 100%;
                     border-radius: (40/16rem);
-                    background: var(--slightlyBelowBackground);
+                    background: var(--slightlyAboveBackground);
                     opacity: .6;
                     position: absolute;
                     display: block;
@@ -1189,7 +1189,7 @@
 
             .cs-vip {
                 &:before {
-                    background-color: var(--slightlyBelowBackground);
+                    background-color: var(--slightlyAboveBackground);
                     opacity: .6;
                 }
             }


### PR DESCRIPTION
## Summary
- update the dark mode pricing cards to use `var(--slightlyAboveBackground)` for the card surface and overlays to better match the theme

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cad4fb6ffc8321b2e24071eb5a390f