### PR TITLE
Adjust dark mode service card background color

### DIFF
--- a/src/assets/less/local.less
+++ b/src/assets/less/local.less
@@ -223,6 +223,9 @@
             background-color: var(--darkBackground);
         }
     }
+    body.dark-mode #services-965 .cs-item {
+        background-color: var(--slightlyAboveBackground);
+    }
     body.dark-mode #services-965 .cs-title,
     body.dark-mode #services-965 .cs-text {
         color: var(--bodyTextColorWhite);


### PR DESCRIPTION
## Summary
- update the services section card styling to use `var(--slightlyAboveBackground)` in dark mode while preserving other styles

## Testing
- `npm run build:eleventy`


------
https://chatgpt.com/codex/tasks/task_e_68cae23e186483218a703c1e165d812b