### PR TITLE
Adjust dark mode service card background color

### DIFF
--- a/src/assets/less/local.less
+++ b/src/assets/less/local.less
@@ -223,6 +223,14 @@
             background-color: var(--darkBackground);
         }
     }
+    body.dark-mode #services-965 .cs-item {
+        background-color: var(--slightlyAboveBackground);
+        color: var(--bodyTextColorWhite);
+    }
+    body.dark-mode #services-965 .cs-item .cs-h3,
+    body.dark-mode #services-965 .cs-item .cs-item-text {
+        color: var(--bodyTextColorWhite);
+    }
     body.dark-mode #services-965 .cs-title,
     body.dark-mode #services-965 .cs-text {
         color: var(--bodyTextColorWhite);


### PR DESCRIPTION
## Summary
- update the services section card styling in dark mode so the cards use `var(--slightlyAboveBackground)` and their text uses `var(--bodyTextColorWhite)`

## Testing
- `npm run build:eleventy`


------
https://chatgpt.com/codex/tasks/task_e_68cae23e186483218a703c1e165d812b