### PR TITLE
Adjust dark mode text color for service cards

### DIFF
--- a/src/assets/less/local.less
+++ b/src/assets/less/local.less
@@ -227,7 +227,10 @@
         background-color: var(--slightlyAboveBackground);
     }
     body.dark-mode #services-965 .cs-title,
-    body.dark-mode #services-965 .cs-text {
+    body.dark-mode #services-965 .cs-text,
+    body.dark-mode #services-965 .cs-h3,
+    body.dark-mode #services-965 .cs-item-text,
+    body.dark-mode #services-965 .cs-link {
         color: var(--bodyTextColorWhite);
     }
 }


### PR DESCRIPTION
## Summary
- update the dark mode rules for the services section so that all card text uses the white body text color for readability

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68caeee05dc88321b0210eeb2591f1a3