### PR TITLE
Fix dark mode plan label text color

### DIFF
--- a/src/assets/less/local.less
+++ b/src/assets/less/local.less
@@ -1205,6 +1205,7 @@
             }
 
             .cs-package {
+                color: var(--buttonText);
                 background-color: var(--darkSecondaryAccent);
 
                 &:before {


### PR DESCRIPTION
## Summary
- set the dark mode plan label text color to use the button text variable for better contrast

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68caf1cfcf6483218c97a17a2ec4c297