### PR TITLE
Point CTA buttons to contact page

### DIFF
--- a/src/_includes/sections/cta.html
+++ b/src/_includes/sections/cta.html
@@ -10,7 +10,7 @@
                 <h2 class="cs-title">Let’s build a website that works as hard as you do.</h2>
             </div>
             <div class="cs-button-box">
-                <a href="/contact/" class="cs-button-solid">Schedule a Free Consultation Today</a>
+                <a href="/contact.html" class="cs-button-solid">Schedule a Free Consultation Today</a>
             </div>
         </div>
     </div>

--- a/src/_includes/sections/header.html
+++ b/src/_includes/sections/header.html
@@ -62,7 +62,7 @@
                 </ul>
             </div>
         </nav>
-        <a href="/contact/" class="cs-button-solid cs-nav-button">Contact Us</a>
+        <a href="/contact.html" class="cs-button-solid cs-nav-button">Contact Us</a>
         <!--Dark Mode toggle, uncomment button code if you want to enable a dark mode toggle-->
         <button id="dark-mode-toggle" aria-label="dark mode toggle">
             <img class="cs-moon" aria-hidden="true" src="/assets/svgs/moon.svg" decoding="async" alt="moon" width="15" height="15">

--- a/src/content/pages/about.html
+++ b/src/content/pages/about.html
@@ -91,7 +91,7 @@ permalink: "/about/"
             <p>
                 Helping small businesses compete with confidence. Whether you’re a local contractor, an accountant, or a startup, your website should work as hard as you do. At Elevate Websites Design, we deliver websites that are not only visually striking but also technically flawless—because your business deserves nothing less.
             </p>
-            <a class="cs-button-solid" href="/contact/">Schedule Your Free Consultation</a>
+            <a class="cs-button-solid" href="/contact.html">Schedule Your Free Consultation</a>
         </div>
         <div class="cs-image-group">
             <picture class="cs-picture">

--- a/src/content/pages/blog.html
+++ b/src/content/pages/blog.html
@@ -83,7 +83,7 @@ permalink: "/blog/"
                             <p class="cs-article-desc">
                                 {{ post.data.description }}
                             </p>
-                            <a href="{{ post.url }}" class="cs-button-solid">Continue Reading</a>
+                            <a href="/contact.html" class="cs-button-solid">Continue Reading</a>
                         </div>
                     </article>
                 {%- endfor -%}

--- a/src/content/pages/project-one.html
+++ b/src/content/pages/project-one.html
@@ -112,7 +112,7 @@ permalink: "/project-one/"
                     <!-- To add more images, copy and paste this row's picture tags here in order from cs-picture-1 to cs-picture-3 and they will maintain the same layout-->
                 </div>
             </div>
-            <a href="/contact/" class="cs-button-solid">Get Started</a>
+            <a href="/contact.html" class="cs-button-solid">Get Started</a>
         </div>
     </section>
 

--- a/src/content/pages/project-two.html
+++ b/src/content/pages/project-two.html
@@ -112,7 +112,7 @@ permalink: "/project-two/"
                     <!-- To add more images, copy and paste this row's picture tags here in order from cs-picture-1 to cs-picture-3 and they will maintain the same layout-->
                 </div>
             </div>
-            <a href="/contact/" class="cs-button-solid">Get Started</a>
+            <a href="/contact.html" class="cs-button-solid">Get Started</a>
         </div>
     </section>
 

--- a/src/content/pages/reviews.html
+++ b/src/content/pages/reviews.html
@@ -183,7 +183,7 @@ permalink: "/reviews/"
                     </div>
                 </li>
             </ul>
-            <a href="/contact/" class="cs-button-solid">Get in Touch</a>
+            <a href="/contact.html" class="cs-button-solid">Get in Touch</a>
         </div>
     </section>
 

--- a/src/content/pages/webDesign.html
+++ b/src/content/pages/webDesign.html
@@ -96,7 +96,7 @@ permalink: "/webDesign/"
             <p>
                 Ready to transform your online presence? Let’s build a website that works as hard as you do.
             </p>
-            <a class="cs-button-solid" href="/contact/">Schedule a Free Consultation Today</a>
+            <a class="cs-button-solid" href="/contact.html">Schedule a Free Consultation Today</a>
         </div>
     </div>
     <div class="cs-bubbles" aria-hidden="true"></div>

--- a/src/index.html
+++ b/src/index.html
@@ -41,7 +41,7 @@ tags: "sitemap" # content/content.json will make sure that all pages in content/
             <p class="cs-text">
                 We don't use page builders or WordPress. We provide superior 100% hand-coded websites, delivering unmatched speed, security, and SEO performance.
             </p>
-            <a href="" class="cs-button-solid">Schedule a Free Consultation</a>
+            <a href="/contact.html" class="cs-button-solid">Schedule a Free Consultation</a>
         </div>
     </div>
     <!--Bubble Groups-->
@@ -88,7 +88,7 @@ tags: "sitemap" # content/content.json will make sure that all pages in content/
                 <p class="cs-item-text">
                     The majority of your customers will find you on their phone. We design for mobile first, ensuring a flawless experience on any device—from smartphones and tablets to desktops.
                 </p>
-                <a href="" class="cs-link">Read More</a>
+                <a href="/contact.html" class="cs-link">Read More</a>
                 <!--Background Image-->
                 <picture class="cs-background">
                     <img loading="lazy" decoding="async" src="https://csimg.nyc3.cdn.digitaloceanspaces.com/Images/MISC/hair1.jpg" alt="hair cut" width="480" height="425">
@@ -102,7 +102,7 @@ tags: "sitemap" # content/content.json will make sure that all pages in content/
                 <p class="cs-item-text">
                     Your business evolves, and your website should too. We offer monthly plans that includes ongoing website maintenance and unlimited small edits, ensuring your site is always secure, updated, and accurate.
                 </p>
-                <a href="" class="cs-link">Read More</a>
+                <a href="/contact.html" class="cs-link">Read More</a>
                 <!--Background Image-->
                 <picture class="cs-background">
                     <img loading="lazy" decoding="async" src="https://csimg.nyc3.cdn.digitaloceanspaces.com/Images/MISC/hair2.jpg" alt="hair cut" width="480" height="425">
@@ -116,7 +116,7 @@ tags: "sitemap" # content/content.json will make sure that all pages in content/
                 <p class="cs-item-text">
                     We build your website from the ground up with clean, efficient code. This means no template bloat, just a lightning-fast, fully custom design tailored to your brand and your customers.
                 </p>
-                <a href="" class="cs-link">Read More</a>
+                <a href="/contact.html" class="cs-link">Read More</a>
                 <!--Background Image-->
                 <picture class="cs-background">
                     <img loading="lazy" decoding="async" src="https://csimg.nyc3.cdn.digitaloceanspaces.com/Images/MISC/hair3.jpg" alt="hair cut" width="480" height="425">
@@ -130,7 +130,7 @@ tags: "sitemap" # content/content.json will make sure that all pages in content/
                 <p class="cs-item-text">
                     Our SEO service perfects the technical foundation we build. We perform an in-depth analysis of your site and implement critical on-page optimizations, from strategic keyword placement in titles and headings to local schema markup, ensuring Google ranks you for what matters.
                 </p>
-                <a href="" class="cs-link">Read More</a>
+                <a href="/contact.html" class="cs-link">Read More</a>
                 <!--Background Image-->
                 <picture class="cs-background">
                     <img loading="lazy" decoding="async" src="https://csimg.nyc3.cdn.digitaloceanspaces.com/Images/MISC/hair1.jpg" alt="hair cut" width="480" height="425">
@@ -144,7 +144,7 @@ tags: "sitemap" # content/content.json will make sure that all pages in content/
                 <p class="cs-item-text">
                     Need leads right now? We can design and manage targeted Google Ad campaigns that place your business in front of customers at the exact moment they're searching for your services. It's the perfect way to generate immediate traffic and measure your ROI.
                 </p>
-                <a href="" class="cs-link">Read More</a>
+                <a href="/contact.html" class="cs-link">Read More</a>
                 <!--Background Image-->
                 <picture class="cs-background">
                     <img loading="lazy" decoding="async" src="https://csimg.nyc3.cdn.digitaloceanspaces.com/Images/MISC/hair2.jpg" alt="hair cut" width="480" height="425">
@@ -158,7 +158,7 @@ tags: "sitemap" # content/content.json will make sure that all pages in content/
                 <p class="cs-item-text">
                     Your project will never be outsourced. All design, development, and support are handled directly by our team right here in the Metro Atlanta area. This guarantees clear communication, direct accountability, and a partner who understands your local market.
                 </p>
-                <a href="" class="cs-link">Read More</a>
+                <a href="/contact.html" class="cs-link">Read More</a>
                 <!--Background Image-->
                 <picture class="cs-background">
                     <img loading="lazy" decoding="async" src="https://csimg.nyc3.cdn.digitaloceanspaces.com/Images/MISC/hair3.jpg" alt="hair cut" width="480" height="425">
@@ -201,7 +201,7 @@ tags: "sitemap" # content/content.json will make sure that all pages in content/
             <p class="cs-text">
                 In a market full of slow, generic template websites, quality is the ultimate advantage. We are dedicated to providing a superior digital foundation for your business, built on three core principles: unparalleled performance, airtight security, and a personal partnership you won't find anywhere else.
             </p>
-            <a href="" class="cs-button-solid">Discover Our Process</a>
+            <a href="/contact.html" class="cs-button-solid">Discover Our Process</a>
         </div>
     </div>
 </section>
@@ -280,7 +280,7 @@ tags: "sitemap" # content/content.json will make sure that all pages in content/
             <p class="cs-text">
                 Elevate was founded in Marietta on a simple belief: small businesses in Atlanta deserve better than slow, cookie-cutter websites. We are passionate about the craft of coding. That's why you see perfect scores for Performance, Accessibility, and Best Practices. For us, it's a measure of quality. For your business, it means more traffic, more leads, and a professional image you can be proud of.
             </p>
-            <a class="cs-button-solid" aria-label="learn more about our programs" href="">Schedule Your Free Consultation</a>
+            <a class="cs-button-solid" aria-label="learn more about our programs" href="/contact.html">Schedule Your Free Consultation</a>
             <ul class="cs-ul">
                 <li class="cs-item">
                     <span class="cs-number">100%</span>
@@ -328,7 +328,7 @@ tags: "sitemap" # content/content.json will make sure that all pages in content/
                         The generated Lorem Ipsum is therefore always free from repetition, injected humour, or non-characteristic.
                     </li>
                 </ul>
-                <a href="" class="cs-button-solid">Buy Subscription</a>
+                <a href="/contact.html" class="cs-button-solid">Buy Subscription</a>
             </li>
             <li class="cs-item">
                 <div class="cs-price-box cs-vip">
@@ -353,7 +353,7 @@ tags: "sitemap" # content/content.json will make sure that all pages in content/
                         Nibh mauris diam augue purus pulvinar id. Egestas felis pellentesque fermentum sed urna, amet. Felis, nec odio eget malesuada.
                     </li>
                 </ul>
-                <a href="" class="cs-button-solid">Buy Subscription</a>
+                <a href="/contact.html" class="cs-button-solid">Buy Subscription</a>
             </li>
         </ul>
     </div>
@@ -392,7 +392,7 @@ tags: "sitemap" # content/content.json will make sure that all pages in content/
             <img src="{% getUrl '/assets/images/JPG/BlueLensWebsite.jpg' | resize({ width:630, height: 411 }) | jpeg %}" alt="library" width="630" height="411" loading="lazy" decoding="async">
         </picture>
     </div>
-    <a href="" class="cs-button-solid">Read More Reviews</a>
+    <a href="/contact.html" class="cs-button-solid">Read More Reviews</a>
 </section>
 
 


### PR DESCRIPTION
## Summary
- point CTA buttons on the homepage to `/contact.html`
- update shared CTA component, header button, and internal page CTAs to contact the team

## Testing
- npm run build:eleventy

------
https://chatgpt.com/codex/tasks/task_e_68caf8f48a4c83219e9abdd8ca4dd0e2