### PR TITLE
Add hover transitions for CTA buttons

### DIFF
--- a/src/assets/less/contact.less
+++ b/src/assets/less/contact.less
@@ -103,6 +103,7 @@
             z-index: 1;
             /* prevents padding from adding to the width */
             box-sizing: border-box;
+            transition: color 0.3s ease, background-color 0.3s ease;
 
             &:before {
                 content: "";
@@ -120,7 +121,9 @@
 
             &:hover {
                 color: var(--buttonText);
+                background-color: var(--primary);
                 &:before {
+                    background-color: var(--primary);
                     width: 100%;
                 }
             }
@@ -138,6 +141,7 @@
 
             &:hover {
                 cursor: pointer;
+                background-color: var(--primary);
             }
         }
 

--- a/src/assets/less/critical.less
+++ b/src/assets/less/critical.less
@@ -146,7 +146,7 @@
             display: inline-block;
             position: relative;
             z-index: 1;
-            transition: color 0.3s;
+            transition: color 0.3s ease, background-color 0.3s ease;
 
             &:before {
                 content: "";
@@ -164,7 +164,9 @@
 
             &:hover {
                 color: var(--buttonText);
+                background-color: var(--primary);
                 &:before {
+                    background-color: var(--primary);
                     width: 100%;
                 }
             }

--- a/src/assets/less/local.less
+++ b/src/assets/less/local.less
@@ -319,7 +319,7 @@
             display: inline-block;
             position: relative;
             z-index: 1;
-            transition: color 0.3s;
+            transition: color 0.3s ease, background-color 0.3s ease;
 
             &:before {
                 content: "";
@@ -337,7 +337,9 @@
 
             &:hover {
                 color: var(--buttonText);
+                background-color: var(--primary);
                 &:before {
+                    background-color: var(--primary);
                     width: 100%;
                 }
             }
@@ -604,7 +606,7 @@
             display: inline-block;
             position: relative;
             z-index: 1;
-            transition: color 0.3s;
+            transition: color 0.3s ease, background-color 0.3s ease;
 
             &:before {
                 content: "";
@@ -622,7 +624,9 @@
 
             &:hover {
                 color: var(--buttonText);
+                background-color: var(--primary);
                 &:before {
+                    background-color: var(--primary);
                     width: 100%;
                 }
             }
@@ -1039,7 +1043,7 @@
             display: inline-block;
             position: relative;
             z-index: 1;
-            transition: color 0.3s;
+            transition: color 0.3s ease, background-color 0.3s ease;
 
             &:before {
                 content: "";
@@ -1057,7 +1061,9 @@
 
             &:hover {
                 color: var(--buttonText);
+                background-color: var(--primary);
                 &:before {
+                    background-color: var(--primary);
                     width: 100%;
                 }
             }
@@ -1077,7 +1083,7 @@
             display: inline-block;
             position: relative;
             z-index: 1;
-            transition: color 0.3s;
+            transition: color 0.3s ease, background-color 0.3s ease;
 
             &:before {
                 content: "";
@@ -1095,7 +1101,9 @@
 
             &:hover {
                 color: var(--buttonText);
+                background-color: var(--primary);
                 &:before {
+                    background-color: var(--primary);
                     width: 100%;
                 }
             }
@@ -1236,7 +1244,7 @@
                 display: inline-block;
                 position: relative;
                 z-index: 1;
-                transition: color 0.3s;
+                transition: color 0.3s ease, background-color 0.3s ease;
 
                 &:before {
                     content: "";
@@ -1254,7 +1262,9 @@
 
                 &:hover {
                     color: var(--buttonText);
+                    background-color: var(--primary);
                     &:before {
+                        background-color: var(--primary);
                         width: 100%;
                     }
                 }
@@ -1391,7 +1401,7 @@
             display: inline-block;
             position: relative;
             z-index: 1;
-            transition: color 0.3s;
+            transition: color 0.3s ease, background-color 0.3s ease;
 
             &:before {
                 content: "";
@@ -1409,7 +1419,9 @@
 
             &:hover {
                 color: var(--buttonText);
+                background-color: var(--primary);
                 &:before {
+                    background-color: var(--primary);
                     width: 100%;
                 }
             }

--- a/src/assets/less/projects.less
+++ b/src/assets/less/projects.less
@@ -134,6 +134,7 @@
             z-index: 1;
             /* prevents padding from adding to the width */
             box-sizing: border-box;
+            transition: color 0.3s ease, background-color 0.3s ease;
 
             &:before {
                 content: "";
@@ -151,7 +152,9 @@
 
             &:hover {
                 color: var(--buttonText);
+                background-color: var(--primary);
                 &:before {
+                    background-color: var(--primary);
                     width: 100%;
                 }
             }

--- a/src/assets/less/root.less
+++ b/src/assets/less/root.less
@@ -130,15 +130,16 @@
 
         // Transition Properties
         color: var(--buttonText);
-        transition: color 0.3s;
-        transition-delay: 0.1s;
+        transition: color 0.3s ease 0.1s, background-color 0.3s ease;
         text-align: center;
 
         &:hover {
             color: var(--buttonText);
+            background-color: var(--primary);
 
             &:before {
                 width: 100%;
+                background-color: var(--primary);
             }
         }
 
@@ -705,6 +706,11 @@
         .cs-button-solid {
             background-color: var(--secondary);
             display: none;
+            transition: background-color 0.3s ease;
+
+            &:hover {
+                background-color: var(--primary);
+            }
         }
     }
 }
@@ -1275,7 +1281,7 @@
             display: inline-block;
             position: relative;
             z-index: 1;
-            transition: color 0.3s;
+            transition: color 0.3s ease, background-color 0.3s ease;
 
             &:before {
                 content: "";
@@ -1293,7 +1299,9 @@
 
             &:hover {
                 color: var(--buttonText);
+                background-color: var(--primary);
                 &:before {
+                    background-color: var(--primary);
                     width: 100%;
                 }
             }


### PR DESCRIPTION
## Summary
- update shared .cs-button-solid styles to transition CTA backgrounds to var(--primary) on hover
- align section-specific button overrides with the new hover behavior, including navigation, contact form, and local landing sections

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb142e0edc8321a4d8e85260c87d18