### PR TITLE
Ensure pricing plan labels use button text color

### DIFF
--- a/src/assets/less/local.less
+++ b/src/assets/less/local.less
@@ -955,7 +955,6 @@
             /* prevents padding from adding to the width */
             box-sizing: border-box;
             padding: (12/16rem) (24/16rem);
-            color: var(--buttonText);
             background-color: var(--secondary);
             overflow: hidden;
             border-radius: (24/16rem);
@@ -976,6 +975,10 @@
                 top: 0;
                 left: 0;
             }
+        }
+
+        .cs-price-box .cs-package {
+            color: var(--buttonText);
         }
 
         .cs-price {
@@ -1213,12 +1216,15 @@
             }
 
             .cs-package {
-                color: var(--buttonText);
                 background-color: var(--darkSecondaryAccent);
 
                 &:before {
                     background: var(--darkSecondaryAccent);
                 }
+            }
+
+            .cs-price-box .cs-package {
+                color: var(--buttonText);
             }
 
             .cs-price,


### PR DESCRIPTION
## Summary
- scope the pricing table label styles so the plan badges inherit `var(--buttonText)` for their text
- ensure both light and dark modes reference the shared color rule without altering existing layout or backgrounds

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb1d693f7083218b8af81f90c1d103