### PR TITLE
Adjust dark mode pricing label text color

### DIFF
--- a/src/assets/less/local.less
+++ b/src/assets/less/local.less
@@ -1216,6 +1216,7 @@
             }
 
             .cs-package {
+                color: var(--buttonText);
                 background-color: var(--darkSecondaryAccent);
 
                 &:before {


### PR DESCRIPTION
## Summary
- ensure the pricing plan label pill text adopts the button text color in dark mode

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cb21b62b6883219a651f175e7de681