### PR TITLE
Move pricing badge overlay behind text

### DIFF
--- a/src/assets/less/local.less
+++ b/src/assets/less/local.less
@@ -969,11 +969,13 @@
                 width: 100%;
                 height: 100%;
 
+                pointer-events: none;
                 opacity: .3;
                 position: absolute;
                 display: block;
                 top: 0;
                 left: 0;
+                z-index: -1;
             }
         }
 


### PR DESCRIPTION
## Summary
- push the `.cs-package::before` overlay behind its text content so the label color renders correctly
- disable pointer events on the pseudo-element to keep interactions unchanged

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc260fb7dc832194fd07a0d3cd0be5