### PR TITLE
Fix about page CTA button color in dark mode

### DIFF
--- a/src/assets/less/about.less
+++ b/src/assets/less/about.less
@@ -281,8 +281,12 @@
                 color: var(--bodyTextColorWhite);
             }
             .cs-color,
-            a {
+            a:not(.cs-button-solid) {
                 color: var(--bodyTextColorWhite);
+            }
+
+            .cs-button-solid {
+                color: var(--buttonText);
             }
 
             p,

--- a/src/assets/less/local.less
+++ b/src/assets/less/local.less
@@ -969,11 +969,13 @@
                 width: 100%;
                 height: 100%;
 
+                pointer-events: none;
                 opacity: .3;
                 position: absolute;
                 display: block;
                 top: 0;
                 left: 0;
+                z-index: -1;
             }
         }
 

--- a/src/assets/less/root.less
+++ b/src/assets/less/root.less
@@ -153,6 +153,7 @@
             display: block;
             background-color: var(--primary);
             height: 100%;
+            pointer-events: none;
 
             //Transition properties
             width: 0;
@@ -303,6 +304,11 @@
         a[role="button"] {
             color: var(--buttonText);
             background-color: var(--secondary);
+        }
+
+        .cs-button-solid,
+        .cs-button-solid:visited {
+            color: var(--buttonText);
         }
 
         .cs-topper {


### PR DESCRIPTION
## Summary
- prevent the About page's dark-mode anchor rule from overriding `.cs-button-solid`
- explicitly restore the global button text color so the "Schedule Your Free Consultation" CTA stays white

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc260fb7dc832194fd07a0d3cd0be5