### PR TITLE
Update pricing section content

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -306,56 +306,76 @@ tags: "sitemap" # content/content.json will make sure that all pages in content/
     <div class="cs-container">
         <div class="cs-content">
             <span class="cs-topper">Our Pricing</span>
-            <h2 class="cs-title">Pricing Plans for Our Services</h2>
+            <h2 class="cs-title">Website Pricing Plans That Put Your Business Ahead</h2>
+            <p>Invest in a <strong>hand-coded, fast, and future-proof website</strong> — built to grow with your business and backed by direct developer support. Based in Atlanta, proudly serving businesses across the United States.</p>
+            <p>At <strong>Elevate Websites Design</strong>, every site is <strong>hand-coded</strong> for speed, airtight security, and mobile-first UX. No bloated page builders. No surprises. And our process is <strong>risk-free</strong>: <em>If we can’t design a website you’re fully satisfied with, we’ll refund you before the site goes live.</em></p>
         </div>
         <ul class="cs-card-group">
             <li class="cs-item">
                 <div class="cs-price-box">
-                    <span class="cs-package">Lump Sum</span>
-                    <span class="cs-price">$2500 + $25/month </span>
+                    <span class="cs-package">Lump Sum – $2500 + $25/month</span>
+                    <span class="cs-price"></span>
                      </div>
+                <p>Best for businesses that want full ownership with minimal ongoing costs.</p>
                 <ul class="cs-ul">
                     <li class="cs-li">
                         <img class="cs-icon" aria-hidden="true" loading="lazy" decoding="async" src="https://csimg.nyc3.cdn.digitaloceanspaces.com/Images/Icons/dark-grey-tick.svg" alt="checkmark" width="24" height="24">
-                        At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos.
+                        Hand-coded, high-performance website tailored to your brand.
                     </li>
                     <li class="cs-li">
                         <img class="cs-icon" aria-hidden="true" loading="lazy" decoding="async" src="https://csimg.nyc3.cdn.digitaloceanspaces.com/Images/Icons/dark-grey-tick.svg" alt="checkmark" width="24" height="24">
-                        Temporibus autem quibusdam et aut officiis debitis aut rum necessitatibus saepe eveniet ut et voluptates repudiandae sint.
+                        $25/month hosting for secure, reliable uptime.
                     </li>
                     <li class="cs-li">
                         <img class="cs-icon" aria-hidden="true" loading="lazy" decoding="async" src="https://csimg.nyc3.cdn.digitaloceanspaces.com/Images/Icons/dark-grey-tick.svg" alt="checkmark" width="24" height="24">
-                        The generated Lorem Ipsum is therefore always free from repetition, injected humour, or non-characteristic.
+                        Option to add unlimited small edits + ongoing maintenance for $50/month.
+                    </li>
+                    <li class="cs-li">
+                        <img class="cs-icon" aria-hidden="true" loading="lazy" decoding="async" src="https://csimg.nyc3.cdn.digitaloceanspaces.com/Images/Icons/dark-grey-tick.svg" alt="checkmark" width="24" height="24">
+                        Mobile-friendly, SEO-ready, and built to load lightning-fast.
+                    </li>
+                    <li class="cs-li">
+                        <img class="cs-icon" aria-hidden="true" loading="lazy" decoding="async" src="https://csimg.nyc3.cdn.digitaloceanspaces.com/Images/Icons/dark-grey-tick.svg" alt="checkmark" width="24" height="24">
+                        Direct developer support — when you call, you reach the person who built your site.
                     </li>
                 </ul>
+                <p><strong>Risk-free:</strong> If you’re not fully satisfied, we’ll refund you before launch.</p>
                 <a href="/contact/" class="cs-button-solid">Buy Subscription</a>
             </li>
             <li class="cs-item">
                 <div class="cs-price-box cs-vip">
-                    <span class="cs-package">Monthly</span>
-                    <span class="cs-price">$150/month</span>
+                    <span class="cs-package">Monthly – $150/month (12-month commitment)</span>
+                    <span class="cs-price"></span>
                      </div>
+                <p>Best for a worry-free, fully managed experience.</p>
                 <ul class="cs-ul">
                     <li class="cs-li">
                         <img class="cs-icon" aria-hidden="true" loading="lazy" decoding="async" src="https://csimg.nyc3.cdn.digitaloceanspaces.com/Images/Icons/dark-grey-tick.svg" alt="checkmark" width="24" height="24">
-                        At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos.
+                        Everything in the Lump Sum plan included.
                     </li>
                     <li class="cs-li">
                         <img class="cs-icon" aria-hidden="true" loading="lazy" decoding="async" src="https://csimg.nyc3.cdn.digitaloceanspaces.com/Images/Icons/dark-grey-tick.svg" alt="checkmark" width="24" height="24">
-                        Temporibus autem quibusdam et aut officiis debitis aut rum necessitatibus saepe eveniet ut et voluptates repudiandae sint.
+                        Unlimited small edits and continuous updates to follow Google’s evolving rules.
                     </li>
                     <li class="cs-li">
                         <img class="cs-icon" aria-hidden="true" loading="lazy" decoding="async" src="https://csimg.nyc3.cdn.digitaloceanspaces.com/Images/Icons/dark-grey-tick.svg" alt="checkmark" width="24" height="24">
-                        The generated Lorem Ipsum is therefore always free from repetition, injected humour, or non-characteristic.
+                        Proactive maintenance to keep your site secure and up to date.
                     </li>
                     <li class="cs-li">
                         <img class="cs-icon" aria-hidden="true" loading="lazy" decoding="async" src="https://csimg.nyc3.cdn.digitaloceanspaces.com/Images/Icons/dark-grey-tick.svg" alt="checkmark" width="24" height="24">
-                        Nibh mauris diam augue purus pulvinar id. Egestas felis pellentesque fermentum sed urna, amet. Felis, nec odio eget malesuada.
+                        Direct developer support — no call centers, no ticket queues.
+                    </li>
+                    <li class="cs-li">
+                        <img class="cs-icon" aria-hidden="true" loading="lazy" decoding="async" src="https://csimg.nyc3.cdn.digitaloceanspaces.com/Images/Icons/dark-grey-tick.svg" alt="checkmark" width="24" height="24">
+                        Predictable pricing with a 12-month commitment.
                     </li>
                 </ul>
+                <p><strong>Risk-free:</strong> If you’re not fully satisfied, we’ll refund you before launch.</p>
                 <a href="/contact/" class="cs-button-solid">Buy Subscription</a>
             </li>
         </ul>
+        <p>Whether you’re looking for a <strong>one-time investment with ownership</strong> or a <strong>monthly managed solution</strong>, our plans deliver <strong>professional, high-performance websites you can trust</strong> — backed by <strong>direct, personal support from your developer</strong>.</p>
+        <p><strong>👉 Choose the plan that fits your business and elevate your online presence today.</strong></p>
     </div>
    </section><!-- ============================================ -->
 <!--                  Reviews                     -->


### PR DESCRIPTION
## Summary
- update the pricing section heading and introductory copy to emphasize hand-coded, developer-supported websites
- refresh each pricing plan card with new taglines, feature lists, and risk-free guarantee messaging
- add a closing CTA reinforcing the value of both pricing options

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68d0abab58ec8321a75bcf0bfdbc3919