### PR TITLE
Limit cs-button-solid hover styles to desktop breakpoints

### DIFF
--- a/src/assets/less/contact.less
+++ b/src/assets/less/contact.less
@@ -118,15 +118,6 @@
                 border-radius: (4/16rem);
                 transition: width 0.3s ease;
             }
-
-            &:hover {
-                color: var(--buttonText);
-                background-color: var(--primary);
-                &:before {
-                    background-color: var(--primary);
-                    width: 100%;
-                }
-            }
         }
 
         .cs-submit {
@@ -283,6 +274,18 @@
             justify-content: space-between;
             align-items: flex-start;
             gap: (80/16rem);
+        }
+
+        .cs-button-solid {
+            &:hover {
+                color: var(--buttonText);
+                background-color: var(--primary);
+
+                &:before {
+                    background-color: var(--primary);
+                    width: 100%;
+                }
+            }
         }
 
         .cs-left-section {

--- a/src/assets/less/critical.less
+++ b/src/assets/less/critical.less
@@ -161,15 +161,6 @@
                 z-index: -1;
                 transition: width 0.3s ease;
             }
-
-            &:hover {
-                color: var(--buttonText);
-                background-color: var(--primary);
-                &:before {
-                    background-color: var(--primary);
-                    width: 100%;
-                }
-            }
         }
 
         .cs-bubbles {
@@ -309,6 +300,23 @@
         .cs-bubbles1 {
             /* changes to auto at large desktop */
             right: (-428/16rem);
+        }
+    }
+}
+
+/* Small Desktop - 1024px */
+@media only screen and (min-width: 64rem) {
+    #hero-1350 {
+        .cs-button-solid {
+            &:hover {
+                color: var(--buttonText);
+                background-color: var(--primary);
+
+                &:before {
+                    background-color: var(--primary);
+                    width: 100%;
+                }
+            }
         }
     }
 }

--- a/src/assets/less/local.less
+++ b/src/assets/less/local.less
@@ -624,15 +624,6 @@
                 z-index: -1;
                 transition: width 0.3s ease;
             }
-
-            &:hover {
-                color: var(--buttonText);
-                background-color: var(--primary);
-                &:before {
-                    background-color: var(--primary);
-                    width: 100%;
-                }
-            }
         }
 
         .cs-ul {
@@ -761,6 +752,18 @@
             flex-direction: row;
             justify-content: space-between;
             align-items: stretch;
+        }
+
+        .cs-button-solid {
+            &:hover {
+                color: var(--buttonText);
+                background-color: var(--primary);
+
+                &:before {
+                    background-color: var(--primary);
+                    width: 100%;
+                }
+            }
         }
 
         .cs-content {
@@ -1066,15 +1069,6 @@
                 z-index: -1;
                 transition: width 0.3s ease;
             }
-
-            &:hover {
-                color: var(--buttonText);
-                background-color: var(--primary);
-                &:before {
-                    background-color: var(--primary);
-                    width: 100%;
-                }
-            }
         }
 
         .cs-button-solid {
@@ -1106,15 +1100,6 @@
                 z-index: -1;
                 transition: width 0.3s ease;
             }
-
-            &:hover {
-                color: var(--buttonText);
-                background-color: var(--primary);
-                &:before {
-                    background-color: var(--primary);
-                    width: 100%;
-                }
-            }
         }
 
         .cs-graphic1 {
@@ -1134,6 +1119,23 @@
             top: (320/16rem);
             left: (0/16rem);
             z-index: 0;
+        }
+    }
+}
+
+/* Small Desktop - 1024px */
+@media only screen and (min-width: 64rem) {
+    #pricing-1843 {
+        .cs-button-solid {
+            &:hover {
+                color: var(--buttonText);
+                background-color: var(--primary);
+
+                &:before {
+                    background-color: var(--primary);
+                    width: 100%;
+                }
+            }
         }
     }
 }
@@ -1269,15 +1271,6 @@
                     left: 0;
                     z-index: -1;
                     transition: width 0.3s ease;
-                }
-
-                &:hover {
-                    color: var(--buttonText);
-                    background-color: var(--primary);
-                    &:before {
-                        background-color: var(--primary);
-                        width: 100%;
-                    }
                 }
             }
 
@@ -1427,15 +1420,6 @@
                 z-index: -1;
                 transition: width 0.3s ease;
             }
-
-            &:hover {
-                color: var(--buttonText);
-                background-color: var(--primary);
-                &:before {
-                    background-color: var(--primary);
-                    width: 100%;
-                }
-            }
         }
     }
 }
@@ -1505,6 +1489,23 @@
             height: clamp(24.8125rem, 37vw, 25.6875rem);
             /* prevents flexbox from squishing it */
             flex: none;
+        }
+    }
+}
+
+/* Small Desktop - 1024px */
+@media only screen and (min-width: 64rem) {
+    #reviews-287 {
+        .cs-button-solid {
+            &:hover {
+                color: var(--buttonText);
+                background-color: var(--primary);
+
+                &:before {
+                    background-color: var(--primary);
+                    width: 100%;
+                }
+            }
         }
     }
 }

--- a/src/assets/less/projects.less
+++ b/src/assets/less/projects.less
@@ -149,10 +149,18 @@
                 border-radius: (4/16rem);
                 transition: width 0.3s ease;
             }
+        }
+    }
+}
 
+/* Small Desktop - 1024px */
+@media only screen and (min-width: 64rem) {
+    #gallery-48 {
+        .cs-button-solid {
             &:hover {
                 color: var(--buttonText);
                 background-color: var(--primary);
+
                 &:before {
                     background-color: var(--primary);
                     width: 100%;

--- a/src/assets/less/root.less
+++ b/src/assets/less/root.less
@@ -133,16 +133,6 @@
         transition: color 0.3s ease 0.1s, background-color 0.3s ease;
         text-align: center;
 
-        &:hover {
-            color: var(--buttonText);
-            background-color: var(--primary);
-
-            &:before {
-                width: 100%;
-                background-color: var(--primary);
-            }
-        }
-
         &:before {
             z-index: -1;
             position: absolute;
@@ -249,6 +239,18 @@
 
     .cs-hide-on-desktop {
         display: none !important;
+    }
+
+    .cs-button-solid {
+        &:hover {
+            color: var(--buttonText);
+            background-color: var(--primary);
+
+            &:before {
+                background-color: var(--primary);
+                width: 100%;
+            }
+        }
     }
 }
 
@@ -713,10 +715,6 @@
             background-color: var(--secondary);
             display: none;
             transition: background-color 0.3s ease;
-
-            &:hover {
-                background-color: var(--primary);
-            }
         }
     }
 }
@@ -820,6 +818,18 @@
 /* Desktop - 1024px */
 @media only screen and (min-width: 1024px) {
     #cs-navigation {
+        .cs-button-solid {
+            &:hover {
+                color: var(--buttonText);
+                background-color: var(--primary);
+
+                &:before {
+                    background-color: var(--primary);
+                    width: 100%;
+                }
+            }
+        }
+
         .cs-dropdown {
             position: relative;
 
@@ -1292,15 +1302,6 @@
                 z-index: -1;
                 transition: width 0.3s ease;
             }
-
-            &:hover {
-                color: var(--buttonText);
-                background-color: var(--primary);
-                &:before {
-                    background-color: var(--primary);
-                    width: 100%;
-                }
-            }
         }
 
 
@@ -1344,6 +1345,18 @@
 /* Small Desktop - 1024px */
 @media only screen and (min-width: 64rem) {
     #cta-1071 {
+        .cs-button-solid {
+            &:hover {
+                color: var(--buttonText);
+                background-color: var(--primary);
+
+                &:before {
+                    background-color: var(--primary);
+                    width: 100%;
+                }
+            }
+        }
+
         .cs-content {
             text-align: left;
             flex-direction: row;


### PR DESCRIPTION
## Summary
- move global `.cs-button-solid` hover styling into desktop-only utilities and reapply it within the navigation and CTA desktop layouts
- drop hover states from mobile breakpoints for the contact form, hero, and projects sections while adding desktop-specific hover rules
- align the side-by-side reverse, pricing, and reviews sections with desktop-only button hover behavior

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d38c1695c083219dfad856963e6969