### PR TITLE
Switch typography to Montserrat and Open Sans

### DIFF
--- a/src/_includes/layouts/base.html
+++ b/src/_includes/layouts/base.html
@@ -30,11 +30,17 @@
 
         <!-- Preloads -->
         <link rel="preload" as="image" href="/assets/svgs/logo-black.svg">
-        <link rel="preload" as="font" type="font/woff2" href="/assets/fonts/roboto-v29-latin-regular.woff2" crossorigin>
-        <link rel="preload" as="font" type="font/woff2" href="/assets/fonts/roboto-v29-latin-700.woff2" crossorigin>
 
         <!-- Sitewide Stylesheets and Scripts -->
         <link rel="stylesheet" href="/assets/css/root.css">
+
+        <!-- Performance preconnects for Google Fonts -->
+        <link rel="preconnect" href="https://fonts.googleapis.com">
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+
+        <!-- Montserrat (300–800) + Open Sans (300–700) with font-display=swap -->
+        <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;500;600;700;800&family=Open+Sans:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+
         <script defer src="/assets/js/dark.js"></script>
         <script defer src="/assets/js/nav.js"></script>
 

--- a/src/admin/decap-preview-styles.css
+++ b/src/admin/decap-preview-styles.css
@@ -17,12 +17,21 @@
 	--bodyFontSize: 1rem;
 
 	/* 60px - 100px top and bottom */
-	--sectionPadding: clamp(3.75rem, 7.82vw, 6.25rem) 1rem;
+        --sectionPadding: clamp(3.75rem, 7.82vw, 6.25rem) 1rem;
+
+        --font-heading: "Montserrat", system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, "Noto Sans", "Liberation Sans", sans-serif;
+        --font-body: "Open Sans", system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, "Noto Sans", "Liberation Sans", sans-serif;
+        --lh-body: 1.6;
+        --lh-heading: 1.2;
+        --ls-heading: 0.005em;
 }
 
 .frame-content {
-	font-family: "Roboto", sans-serif;
-	line-height: 1.6em;
+        font-family: var(--font-body);
+        line-height: var(--lh-body);
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
+        text-rendering: optimizeLegibility;
 }
 
 .frame-content h1,
@@ -31,8 +40,27 @@
 .frame-content h4,
 .frame-content h5,
 .frame-content h6 {
-	font-family: "Roboto", sans-serif;
-	color: var(--headerColor);
+        font-family: var(--font-heading);
+        line-height: var(--lh-heading);
+        letter-spacing: var(--ls-heading);
+        color: var(--headerColor);
+}
+
+.frame-content h1,
+.frame-content h2 {
+        font-weight: 700;
+}
+
+.frame-content h3,
+.frame-content h4,
+.frame-content h5,
+.frame-content h6 {
+        font-weight: 600;
+}
+
+.frame-content strong,
+.frame-content b {
+        font-weight: 600;
 }
 
 .frame-content img {

--- a/src/assets/less/root.less
+++ b/src/assets/less/root.less
@@ -43,8 +43,15 @@
         /* 60px - 100px top and bottom */
         --sectionPadding: clamp(3.75rem, 7.82vw, 6.25rem) 1rem;
 
-        --headerFont: "Roboto", Arial, sans-serif;
-        --bodyFont: "Roboto", Arial, sans-serif;
+        --font-heading: "Montserrat", system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, "Noto Sans", "Liberation Sans", sans-serif;
+        --font-body: "Open Sans", system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, "Noto Sans", "Liberation Sans", sans-serif;
+
+        --lh-body: 1.6;
+        --lh-heading: 1.2;
+        --ls-heading: 0.005em;
+
+        --headerFont: var(--font-heading);
+        --bodyFont: var(--font-body);
     }
 
     html,
@@ -53,9 +60,13 @@
         padding: 0;
         overflow-x: hidden;
         font-family: var(--bodyFont);
+        line-height: var(--lh-body);
         font-size: 100%;
         transition: background-color 0.3s;
         color: var(--bodyTextColor);
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
+        text-rendering: optimizeLegibility;
     }
 
     *,
@@ -68,6 +79,7 @@
     }
 
     .cs-topper {
+        font-family: var(--headerFont);
         font-size: var(--topperFontSize);
         line-height: 1.2em;
         text-transform: uppercase;
@@ -80,6 +92,7 @@
     }
 
     .cs-title {
+        font-family: var(--headerFont);
         font-size: var(--headerFontSize);
         font-weight: 900;
         line-height: 1.2em;
@@ -261,17 +274,57 @@
     h3,
     h4,
     h5,
-    h6 {
+    h6,
+    .section-title,
+    .card-title,
+    .hero-title {
         font-family: var(--headerFont);
-        line-height: 1.2em;
+        line-height: var(--lh-heading);
+        letter-spacing: var(--ls-heading);
         color: var(--headerColor);
+    }
+
+    h1 {
+        font-weight: 700;
+    }
+
+    h2 {
+        font-weight: 700;
+    }
+
+    h3 {
+        font-weight: 600;
+    }
+
+    h4,
+    h5,
+    h6,
+    .section-title,
+    .card-title,
+    .hero-title {
+        font-weight: 600;
     }
 
     p,
     li,
     a {
         font-size: (16/16rem);
-        line-height: 1.5em;
+    }
+
+    p,
+    li,
+    input,
+    textarea,
+    label,
+    small {
+        font-family: var(--bodyFont);
+        font-weight: 400;
+        line-height: var(--lh-body);
+    }
+
+    a {
+        font-family: var(--bodyFont);
+        font-weight: 400;
     }
 
     p,
@@ -281,6 +334,25 @@
         a {
             color: var(--primary);
         }
+    }
+
+    strong,
+    b {
+        font-weight: 600;
+    }
+
+    .button,
+    .btn,
+    .cta,
+    nav a,
+    .menu a,
+    .cs-button-solid,
+    .cs-button-solid:visited,
+    .cs-button-transparent,
+    .cs-link {
+        font-family: var(--headerFont);
+        font-weight: 600;
+        letter-spacing: 0.01em;
     }
 
     a,
@@ -334,40 +406,6 @@
                 color: inherit;
             }
         }
-    }
-}
-
-/* Fonts */
-@media only screen and (min-width: 0rem) {
-    // Grab your fonts to locally host from https://gwfh.mranftl.com/fonts
-    /* roboto-regular - latin */
-    @font-face {
-        font-style: normal;
-        font-family: "Roboto";
-        font-weight: 400;
-        font-display: swap;
-        src: local(""), url("/assets/fonts/roboto-v29-latin-regular.woff2") format("woff2"),
-            /* Chrome 26+, Opera 23+, Firefox 39+ */ url("/assets/fonts/roboto-v29-latin-regular.woff") format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
-    }
-
-    /* roboto-700 - latin */
-    @font-face {
-        font-style: normal;
-        font-family: "Roboto";
-        font-weight: 700;
-        font-display: swap;
-        src: local(""), url("/assets/fonts/roboto-v29-latin-700.woff2") format("woff2"),
-            /* Chrome 26+, Opera 23+, Firefox 39+ */ url("/assets/fonts/roboto-v29-latin-700.woff") format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
-    }
-
-    /* roboto-900 - latin */
-    @font-face {
-        font-style: normal;
-        font-family: "Roboto";
-        font-weight: 900;
-        font-display: swap;
-        src: local(""), url("/assets/fonts/roboto-v29-latin-900.woff2") format("woff2"),
-            /* Chrome 26+, Opera 23+, Firefox 39+ */ url("/assets/fonts/roboto-v29-latin-900.woff") format("woff"); /* Chrome 6+, Firefox 3.6+, IE 9+, Safari 5.1+ */
     }
 }
 


### PR DESCRIPTION
## Summary
- load Montserrat and Open Sans from Google Fonts with preconnect hints for better performance
- add global typography variables and update base styles so headings/nav/buttons use Montserrat while body copy uses Open Sans
- remove legacy Roboto font-face declarations and align Decap CMS preview styles with the new typography system

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4c0653ee4832184a970f0bf4c18c2