### PR TITLE
Add responsive CTA button text logic

### DIFF
--- a/src/_includes/layouts/base.html
+++ b/src/_includes/layouts/base.html
@@ -43,6 +43,7 @@
 
         <script defer src="/assets/js/dark.js"></script>
         <script defer src="/assets/js/nav.js"></script>
+        <script defer src="/assets/js/cta.js"></script>
 
         {% block head %}{% endblock %}
 

--- a/src/_includes/sections/cta.html
+++ b/src/_includes/sections/cta.html
@@ -10,7 +10,7 @@
                 <h2 class="cs-title">Let’s build a website that works as hard as you do. Hand-coded. SEO-ready. Built for growth.</h2>
             </div>
             <div class="cs-button-box">
-                <a href="/contact/" class="cs-button-solid">Schedule a Free Consultation</a>
+                <a href="/contact/" class="cs-button-solid cta">Schedule a Free Consultation</a>
             </div>
         </div>
     </div>

--- a/src/assets/js/cta.js
+++ b/src/assets/js/cta.js
@@ -1,0 +1,35 @@
+(function () {
+    const CTA_SELECTORS = ".cta";
+
+    function getCtaText(width) {
+        if (width < 400) {
+            return "Contact Us!";
+        }
+
+        if (width < 425) {
+            return "Schedule a consultation";
+        }
+
+        if (width < 500) {
+            return "Schedule a Free Consultation";
+        }
+
+        return "Schedule a Free Consultation Today!";
+    }
+
+    function updateCtaButtons() {
+        const ctaButtons = document.querySelectorAll(CTA_SELECTORS);
+        if (!ctaButtons.length) {
+            return;
+        }
+
+        const text = getCtaText(window.innerWidth);
+        ctaButtons.forEach((button) => {
+            button.textContent = text;
+        });
+    }
+
+    window.addEventListener("resize", updateCtaButtons);
+    window.addEventListener("DOMContentLoaded", updateCtaButtons);
+    updateCtaButtons();
+})();

--- a/src/content/pages/project-one.html
+++ b/src/content/pages/project-one.html
@@ -112,7 +112,7 @@ permalink: "/project-one/"
                     <!-- To add more images, copy and paste this row's picture tags here in order from cs-picture-1 to cs-picture-3 and they will maintain the same layout-->
                 </div>
             </div>
-            <a href="/contact/" class="cs-button-solid">Get Started</a>
+            <a href="/contact/" class="cs-button-solid cta">Get Started</a>
         </div>
     </section>
 

--- a/src/content/pages/project-two.html
+++ b/src/content/pages/project-two.html
@@ -112,7 +112,7 @@ permalink: "/project-two/"
                     <!-- To add more images, copy and paste this row's picture tags here in order from cs-picture-1 to cs-picture-3 and they will maintain the same layout-->
                 </div>
             </div>
-            <a href="/contact/" class="cs-button-solid">Get Started</a>
+            <a href="/contact/" class="cs-button-solid cta">Get Started</a>
         </div>
     </section>
 

--- a/src/content/pages/reviews.html
+++ b/src/content/pages/reviews.html
@@ -183,7 +183,7 @@ permalink: "/reviews/"
                     </div>
                 </li>
             </ul>
-            <a href="/contact/" class="cs-button-solid">Get in Touch</a>
+            <a href="/contact/" class="cs-button-solid cta">Get in Touch</a>
         </div>
     </section>
 

--- a/src/content/pages/seo.html
+++ b/src/content/pages/seo.html
@@ -97,7 +97,7 @@ permalink: "/SEO/"
                 <li>Implementation — Technical fixes, on-page updates, and content improvements.</li>
                 <li>Measure &amp; Iterate — Track rankings, traffic, and conversions; adjust monthly.</li>
             </ol>
-            <a class="cs-button-solid" href="/contact/">Schedule a Free Consultation Today</a>
+            <a class="cs-button-solid cta" href="/contact/">Schedule a Free Consultation Today</a>
         </div>
     </div>
     <div class="cs-bubbles" aria-hidden="true"></div>

--- a/src/index.html
+++ b/src/index.html
@@ -99,7 +99,7 @@ tags: "sitemap" # content/content.json will make sure that all pages in content/
             <p class="cs-text">
                 Hand-coded, lightning-fast, and built with SEO from the start. Elevate Websites Design helps small businesses nationwide stand out online with secure, modern websites that convert visitors into customers.
             </p>
-            <a href="/contact/" class="cs-button-solid">Get Your Free Consultation</a>
+            <a href="/contact/" class="cs-button-solid cta">Get Your Free Consultation</a>
         </div>
     </div>
     <!--Bubble Groups-->
@@ -259,7 +259,7 @@ tags: "sitemap" # content/content.json will make sure that all pages in content/
             <p class="cs-text">
                 Why settle for ordinary when your business deserves extraordinary? At Elevate Websites Design, we give you a competitive edge with lightning-fast, 100% secure websites and ongoing support that keeps your online presence strong.
             </p>
-            <a href="/contact/" class="cs-button-solid">Get Started Today</a>
+            <a href="/contact/" class="cs-button-solid cta">Get Started Today</a>
         </div>
     </div>
 </section>
@@ -336,7 +336,7 @@ tags: "sitemap" # content/content.json will make sure that all pages in content/
             <p class="cs-text">
                 Your website should be a growth engine, not a headache. With Elevate Websites Design, you get a reliable partner who cares about your business as much as you do. From consultation to launch — and long after — we’re here to support your success.
             </p>
-            <a class="cs-button-solid" aria-label="learn more about our programs" href="/contact/">Schedule Your Consultation</a>
+            <a class="cs-button-solid cta" aria-label="learn more about our programs" href="/contact/">Schedule Your Consultation</a>
             <ul class="cs-ul">
                 <li class="cs-item">
                     <span class="cs-number">100%</span>
@@ -403,7 +403,7 @@ tags: "sitemap" # content/content.json will make sure that all pages in content/
                         <strong>Risk-free satisfaction guarantee. If we can’t design a site you’re fully satisfied with, we’ll refund you before launch</strong>
                     </li>
                 </ul>
-                <a href="/contact/" class="cs-button-solid">Buy Subscription</a>
+                <a href="/contact/" class="cs-button-solid cta">Buy Subscription</a>
             </li>
             <li class="cs-item">
                 <div class="cs-price-box cs-vip">
@@ -443,7 +443,7 @@ tags: "sitemap" # content/content.json will make sure that all pages in content/
                         <strong>Risk-free satisfaction guarantee. If we can’t design a site you’re fully satisfied with, we’ll refund you before launch</strong>
                     </li>
                 </ul>
-                <a href="/contact/" class="cs-button-solid">Buy Subscription</a>
+                <a href="/contact/" class="cs-button-solid cta">Buy Subscription</a>
             </li>
         </ul>
     </div>


### PR DESCRIPTION
## Summary
- add a global script that updates CTA button copy based on the viewport width
- mark CTA buttons across templates with a shared class and load the new script sitewide

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4c82466088321852806d4c6393094