### PR TITLE
Update default meta image to new logo

### DIFF
--- a/src/_includes/layouts/base.html
+++ b/src/_includes/layouts/base.html
@@ -16,8 +16,8 @@
         <meta property="og:description" content="{{ description }}"/>
         <meta property="og:type" content="website"/>
         <meta property="og:url" content="{{ client.domain }}{{ page.url }}"/>
-        <meta property="og:image" content="{{ image or "/assets/images/logo-small.png" }}"/>
-        <meta property="og:image:secure_url" content="{{ image or "/assets/images/logo-small.png" }}"/>
+        <meta property="og:image" content="{{ image or "/assets/images/JPG/Logo.jpg" }}"/>
+        <meta property="og:image:secure_url" content="{{ image or "/assets/images/JPG/Logo.jpg" }}"/>
 
         <!--Favicons-->
         <!-- https://realfavicongenerator.net/ -->


### PR DESCRIPTION
## Summary
- update the default Open Graph image fallback to point to the new logo asset

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d50fc649f88321b696cdb62e873ce8