### PR TITLE
Fix mobile nav toggle element semantics

### DIFF
--- a/src/_includes/sections/header.html
+++ b/src/_includes/sections/header.html
@@ -12,11 +12,11 @@
         <nav class="cs-nav">
             <!--Mobile Nav Toggle-->
             <button class="cs-toggle" aria-label="mobile menu toggle">
-                <div class="cs-box" aria-hidden="true">
+                <span class="cs-box" aria-hidden="true">
                     <span class="cs-line cs-line1" aria-hidden="true"></span>
                     <span class="cs-line cs-line2" aria-hidden="true"></span>
                     <span class="cs-line cs-line3" aria-hidden="true"></span>
-                </div>
+                </span>
             </button>
             <!-- We need a wrapper div so we can set a fixed height on the cs-ul in case the nav list gets too long from too many dropdowns being opened and needs to have an overflow scroll. This wrapper acts as the background so it can go the full height of the screen and not cut off any overflowing nav items while the cs-ul stops short of the bottom of the screen, which keeps all nav items in view no matter how mnay there are-->
             <div class="cs-ul-wrapper">

--- a/src/assets/less/root.less
+++ b/src/assets/less/root.less
@@ -622,6 +622,7 @@
             width: clamp(1.5rem, 2vw, 1.75rem);
             /* 14px - 16px */
             height: clamp(0.875rem, 1.5vw, 1rem);
+            display: block;
             position: relative;
         }
 


### PR DESCRIPTION
## Summary
- replace the mobile menu toggle container div with a span to improve semantics
- ensure the toggle box retains layout by setting it to display block in the LESS styles

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc838db9cc83219908bf5707fbb8a5