### PR TITLE
Add explicit form-name hidden field to contact form

### DIFF
--- a/src/content/pages/contact.html
+++ b/src/content/pages/contact.html
@@ -56,6 +56,7 @@ permalink: "/contact/"
                     <h2 class="cs-title">Get in Touch</h2>
                 </div>
                 <form id="cs-form-265" name="Contact Form" method="post" netlify>
+                    <input type="hidden" name="form-name" value="Contact Form">
                     <label>
                         Name
                         <input required type="text" id="name-265" name="name" placeholder="Name">


### PR DESCRIPTION
## Summary
- add a hidden form-name input to the Netlify contact form so the field is explicitly present in the markup

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc8e0543c083219c7301b5052dd7b1