### PR TITLE
Fix FAQ accordion markup to avoid invalid button children

### DIFF
--- a/src/content/pages/FAQ.html
+++ b/src/content/pages/FAQ.html
@@ -70,151 +70,151 @@ permalink: "/FAQ/"
                 <!-- Active class added as default -->
                 <li class="cs-faq-item active">
                     <button class="cs-button">
-                        <div class="cs-flex">
+                        <span class="cs-flex">
                             <span class="cs-button-text"> What types of businesses do you work with? </span>
-                            <p class="cs-item-p">
-                                We specialize in building hand-coded, secure, and fast-loading websites for small businesses, startups, and entrepreneurs. Whether you’re a local service provider in Atlanta or a national brand seeking a sleek online presence, we tailor every project to your unique goals.
-                            </p>
-                            <p class="cs-item-p">
-                                Common clients include contractors, restaurants, photographers, accountants, and more—but our approach works for any industry that wants a high-performing website.
-                            </p>
-                        </div>
+                        </span>
                         <img class="cs-icon" loading="lazy" decoding="async" src="https://csimg.nyc3.cdn.digitaloceanspaces.com/Images/Icons/arrow-dwon2.svg" alt="icon" width="24" height="24"/>
                     </button>
+                    <p class="cs-item-p">
+                        We specialize in building hand-coded, secure, and fast-loading websites for small businesses, startups, and entrepreneurs. Whether you’re a local service provider in Atlanta or a national brand seeking a sleek online presence, we tailor every project to your unique goals.
+                    </p>
+                    <p class="cs-item-p">
+                        Common clients include contractors, restaurants, photographers, accountants, and more—but our approach works for any industry that wants a high-performing website.
+                    </p>
                 </li>
                 <li class="cs-faq-item">
                     <button class="cs-button">
-                        <div class="cs-flex">
+                        <span class="cs-flex">
                             <span class="cs-button-text"> How much does a website cost? </span>
-                            <p class="cs-item-p">
-                                We offer flexible pricing models designed for small business budgets.
-                            </p>
-                            <ul class="cs-item-p">
-                                <li><strong>Lump Sum Plan</strong> — Starting at $2,500 with a one-time build cost, plus $25/month for hosting and maintenance.</li>
-                                <li><strong>Monthly Plan</strong> — $150/month, with no upfront cost, perfect for startups who want to spread out expenses.</li>
-                            </ul>
-                            <p class="cs-item-p">
-                                Both plans include unlimited edits, built-in SEO, and ongoing support, so you never have to worry about hidden fees or surprise charges.
-                            </p>
-                        </div>
+                        </span>
                         <img class="cs-icon" loading="lazy" decoding="async" src="https://csimg.nyc3.cdn.digitaloceanspaces.com/Images/Icons/arrow-dwon2.svg" alt="icon" width="24" height="24"/>
                     </button>
+                    <p class="cs-item-p">
+                        We offer flexible pricing models designed for small business budgets.
+                    </p>
+                    <ul class="cs-item-p">
+                        <li><strong>Lump Sum Plan</strong> — Starting at $2,500 with a one-time build cost, plus $25/month for hosting and maintenance.</li>
+                        <li><strong>Monthly Plan</strong> — $150/month, with no upfront cost, perfect for startups who want to spread out expenses.</li>
+                    </ul>
+                    <p class="cs-item-p">
+                        Both plans include unlimited edits, built-in SEO, and ongoing support, so you never have to worry about hidden fees or surprise charges.
+                    </p>
                 </li>
                 <li class="cs-faq-item">
                     <button class="cs-button">
-                        <div class="cs-flex">
+                        <span class="cs-flex">
                             <span class="cs-button-text"> What makes your websites different from template-based builders like Wix or Squarespace? </span>
-                            <p class="cs-item-p">
-                                Unlike cookie-cutter solutions, our websites are hand-coded from scratch. That means:
-                            </p>
-                            <ul class="cs-item-p">
-                                <li>No bloated plugins or drag-and-drop builders slowing things down.</li>
-                                <li>100% security (no vulnerable databases to hack).</li>
-                                <li>Near-perfect PageSpeed performance—visitors don’t bounce due to lag.</li>
-                                <li>Built-in SEO foundations from day one so your site actually gets found.</li>
-                            </ul>
-                            <p class="cs-item-p">
-                                Your website isn’t just pretty—it’s a business tool designed to attract traffic, convert leads, and support growth.
-                            </p>
-                        </div>
+                        </span>
                         <img class="cs-icon" loading="lazy" decoding="async" src="https://csimg.nyc3.cdn.digitaloceanspaces.com/Images/Icons/arrow-dwon2.svg" alt="icon" width="24" height="24"/>
                     </button>
+                    <p class="cs-item-p">
+                        Unlike cookie-cutter solutions, our websites are hand-coded from scratch. That means:
+                    </p>
+                    <ul class="cs-item-p">
+                        <li>No bloated plugins or drag-and-drop builders slowing things down.</li>
+                        <li>100% security (no vulnerable databases to hack).</li>
+                        <li>Near-perfect PageSpeed performance—visitors don’t bounce due to lag.</li>
+                        <li>Built-in SEO foundations from day one so your site actually gets found.</li>
+                    </ul>
+                    <p class="cs-item-p">
+                        Your website isn’t just pretty—it’s a business tool designed to attract traffic, convert leads, and support growth.
+                    </p>
                 </li>
                 <li class="cs-faq-item">
                     <button class="cs-button">
-                        <div class="cs-flex">
+                        <span class="cs-flex">
                             <span class="cs-button-text"> Will my website be optimized for mobile and SEO? </span>
-                            <p class="cs-item-p">
-                                Yes. Every site we build is mobile-first and comes with SEO baked in. That means responsive design for all devices, optimized code, keyword-aware content structure, and technical SEO best practices to give you a head start in Google rankings.
-                            </p>
-                        </div>
+                        </span>
                         <img class="cs-icon" loading="lazy" decoding="async" src="https://csimg.nyc3.cdn.digitaloceanspaces.com/Images/Icons/arrow-dwon2.svg" alt="icon" width="24" height="24"/>
                     </button>
+                    <p class="cs-item-p">
+                        Yes. Every site we build is mobile-first and comes with SEO baked in. That means responsive design for all devices, optimized code, keyword-aware content structure, and technical SEO best practices to give you a head start in Google rankings.
+                    </p>
                 </li>
                 <li class="cs-faq-item">
                     <button class="cs-button">
-                        <div class="cs-flex">
+                        <span class="cs-flex">
                             <span class="cs-button-text"> How long does it take to build my website? </span>
-                            <p class="cs-item-p">
-                                On average, most projects are completed within 4–6 weeks from consultation to launch. The timeline depends on the complexity of your site and how quickly we receive content and feedback.
-                            </p>
-                            <p class="cs-item-p">
-                                Because we don’t rely on templates, every site is custom—but we keep the process efficient so you can launch fast.
-                            </p>
-                        </div>
+                        </span>
                         <img class="cs-icon" loading="lazy" decoding="async" src="https://csimg.nyc3.cdn.digitaloceanspaces.com/Images/Icons/arrow-dwon2.svg" alt="icon" width="24" height="24"/>
                     </button>
+                    <p class="cs-item-p">
+                        On average, most projects are completed within 4–6 weeks from consultation to launch. The timeline depends on the complexity of your site and how quickly we receive content and feedback.
+                    </p>
+                    <p class="cs-item-p">
+                        Because we don’t rely on templates, every site is custom—but we keep the process efficient so you can launch fast.
+                    </p>
                 </li>
             </ul>
             <ul class="cs-faq-group cs-faq-group2">
                 <li class="cs-faq-item">
                     <button class="cs-button">
-                        <div class="cs-flex">
+                        <span class="cs-flex">
                             <span class="cs-button-text"> Can you redesign my existing website? </span>
-                            <p class="cs-item-p">
-                                Yes. If your current site is outdated, slow, or underperforming, we can redesign it from the ground up into a modern, fast, and SEO-ready website that better reflects your brand.
-                            </p>
-                        </div>
+                        </span>
                         <img class="cs-icon" loading="lazy" decoding="async" src="https://csimg.nyc3.cdn.digitaloceanspaces.com/Images/Icons/arrow-dwon2.svg" alt="icon" width="24" height="24"/>
                     </button>
+                    <p class="cs-item-p">
+                        Yes. If your current site is outdated, slow, or underperforming, we can redesign it from the ground up into a modern, fast, and SEO-ready website that better reflects your brand.
+                    </p>
                 </li>
                 <li class="cs-faq-item">
                     <button class="cs-button">
-                        <div class="cs-flex">
+                        <span class="cs-flex">
                             <span class="cs-button-text"> Do you provide ongoing support after launch? </span>
-                            <p class="cs-item-p">
-                                Absolutely. Every client gets direct access to the developer who built their site—no ticketing systems, no long waits.
-                            </p>
-                            <p class="cs-item-p">
-                                We include ongoing edits, performance monitoring, and SEO support in our monthly plans to ensure your site continues to grow with your business.
-                            </p>
-                        </div>
+                        </span>
                         <img class="cs-icon" loading="lazy" decoding="async" src="https://csimg.nyc3.cdn.digitaloceanspaces.com/Images/Icons/arrow-dwon2.svg" alt="icon" width="24" height="24"/>
                     </button>
+                    <p class="cs-item-p">
+                        Absolutely. Every client gets direct access to the developer who built their site—no ticketing systems, no long waits.
+                    </p>
+                    <p class="cs-item-p">
+                        We include ongoing edits, performance monitoring, and SEO support in our monthly plans to ensure your site continues to grow with your business.
+                    </p>
                 </li>
                 <li class="cs-faq-item">
                     <button class="cs-button">
-                        <div class="cs-flex">
+                        <span class="cs-flex">
                             <span class="cs-button-text"> Do you only serve Atlanta businesses? </span>
-                            <p class="cs-item-p">
-                                We’re proud to be based in Atlanta, GA, but we serve clients nationwide. Whether you’re local or out-of-state, our process delivers the same personal support and premium results no matter where you’re located.
-                            </p>
-                        </div>
+                        </span>
                         <img class="cs-icon" loading="lazy" decoding="async" src="https://csimg.nyc3.cdn.digitaloceanspaces.com/Images/Icons/arrow-dwon2.svg" alt="icon" width="24" height="24"/>
                     </button>
+                    <p class="cs-item-p">
+                        We’re proud to be based in Atlanta, GA, but we serve clients nationwide. Whether you’re local or out-of-state, our process delivers the same personal support and premium results no matter where you’re located.
+                    </p>
                 </li>
                 <li class="cs-faq-item">
                     <button class="cs-button">
-                        <div class="cs-flex">
+                        <span class="cs-flex">
                             <span class="cs-button-text"> How do I get started? </span>
-                            <p class="cs-item-p">
-                                Getting started is easy. Schedule your free consultation, and we’ll walk you through your options, learn about your goals, and recommend the best plan for your business.
-                            </p>
-                            <p class="cs-item-p">
-                                From there, we send you a detailed questionnaire to learn more about your business, brand, and goals. Once we receive that back, we handle everything—design, development, SEO, and support—so you can stay focused on running your business.
-                            </p>
-                        </div>
+                        </span>
                         <img class="cs-icon" loading="lazy" decoding="async" src="https://csimg.nyc3.cdn.digitaloceanspaces.com/Images/Icons/arrow-dwon2.svg" alt="icon" width="24" height="24"/>
                     </button>
+                    <p class="cs-item-p">
+                        Getting started is easy. Schedule your free consultation, and we’ll walk you through your options, learn about your goals, and recommend the best plan for your business.
+                    </p>
+                    <p class="cs-item-p">
+                        From there, we send you a detailed questionnaire to learn more about your business, brand, and goals. Once we receive that back, we handle everything—design, development, SEO, and support—so you can stay focused on running your business.
+                    </p>
                 </li>
                 <li class="cs-faq-item">
                     <button class="cs-button">
-                        <div class="cs-flex">
+                        <span class="cs-flex">
                             <span class="cs-button-text"> Do you offer other digital marketing services besides web design? </span>
-                            <p class="cs-item-p">
-                                Yes. In addition to custom websites, we provide:
-                            </p>
-                            <ul class="cs-item-p">
-                                <li><strong>SEO services</strong> — keyword strategy, on-page optimization, and technical fixes.</li>
-                                <li><strong>Google Ads management</strong> — campaign setup, targeting, and ROI tracking.</li>
-                                <li><strong>Branding support</strong> — logos, color systems, typography.</li>
-                            </ul>
-                            <p class="cs-item-p">
-                                This all-in-one approach ensures your business gets not just a website, but a complete digital foundation.
-                            </p>
-                        </div>
+                        </span>
                         <img class="cs-icon" loading="lazy" decoding="async" src="https://csimg.nyc3.cdn.digitaloceanspaces.com/Images/Icons/arrow-dwon2.svg" alt="icon" width="24" height="24"/>
                     </button>
+                    <p class="cs-item-p">
+                        Yes. In addition to custom websites, we provide:
+                    </p>
+                    <ul class="cs-item-p">
+                        <li><strong>SEO services</strong> — keyword strategy, on-page optimization, and technical fixes.</li>
+                        <li><strong>Google Ads management</strong> — campaign setup, targeting, and ROI tracking.</li>
+                        <li><strong>Branding support</strong> — logos, color systems, typography.</li>
+                    </ul>
+                    <p class="cs-item-p">
+                        This all-in-one approach ensures your business gets not just a website, but a complete digital foundation.
+                    </p>
                 </li>
             </ul>
         </div>


### PR DESCRIPTION
## Summary
- update the FAQ accordion so each button only wraps the heading text and icon
- move the answer content outside the buttons to keep the layout and interactivity intact while satisfying HTML semantics

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc8dc3b1788321a20c0c4eb867a84c