### PR TITLE
Adjust FAQ expanded card padding

### DIFF
--- a/src/assets/less/FAQ.less
+++ b/src/assets/less/FAQ.less
@@ -104,8 +104,7 @@
 
         .faq-body {
           opacity: 1;
-          padding-top: (8/16rem);
-          padding-bottom: (24/16rem);
+          padding: (24/16rem);
           max-height: (960/16rem);
         }
       }


### PR DESCRIPTION
## Summary
- increase the padding applied to FAQ content when a card is expanded so the text has consistent breathing room on all sides

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ddebb810008321adf1c198d4a9c2f5